### PR TITLE
Add missing quote in AssemblyInfo. Resolve names collision in sample.

### DIFF
--- a/csharp/ContextMenu.WinForms/Form1.cs
+++ b/csharp/ContextMenu.WinForms/Form1.cs
@@ -105,7 +105,7 @@ namespace ContextMenu.WinForms
             {
                 BeginInvoke(new Action(() =>
                 {
-                    ContextMenu popupMenu = new ContextMenu();
+                    System.Windows.Forms.ContextMenu popupMenu = new System.Windows.Forms.ContextMenu();
                     IEnumerable<string> suggestions = spellCheckMenu.DictionarySuggestions;
                     if (suggestions != null)
                     {

--- a/csharp/UiAutomation.Wpf/Properties/AssemblyInfo.cs
+++ b/csharp/UiAutomation.Wpf/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("TeamDev")]
 [assembly: AssemblyProduct("UiAutomation.Wpf")]
-[assembly: AssemblyCopyright("Copyright © 2020, TeamDev. All rights reserved.)]
+[assembly: AssemblyCopyright("Copyright © 2020, TeamDev. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This PR fixes compilation errors found in C# projects after renaming.