### PR TITLE
Add InjectObjectForScripting example

### DIFF
--- a/csharp/DotNetBrowser.Examples.sln
+++ b/csharp/DotNetBrowser.Examples.sln
@@ -89,6 +89,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SaveImageFromPage", "SaveIm
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullScreen.WinForms", "FullScreen.WinForms\FullScreen.WinForms.csproj", "{CDD33926-0653-4AE0-A1CF-E6BA2606293D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InjectObjectForScripting", "InjectObjectForScripting\InjectObjectForScripting.csproj", "{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -263,6 +265,10 @@ Global
 		{CDD33926-0653-4AE0-A1CF-E6BA2606293D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDD33926-0653-4AE0-A1CF-E6BA2606293D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDD33926-0653-4AE0-A1CF-E6BA2606293D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/InjectObjectForScripting/App.config
+++ b/csharp/InjectObjectForScripting/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/csharp/InjectObjectForScripting/InjectObjectForScripting.csproj
+++ b/csharp/InjectObjectForScripting/InjectObjectForScripting.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>InjectObjectForScripting</RootNamespace>
+    <AssemblyName>InjectObjectForScripting</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="DotNetBrowser, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.0.0\lib\net45\DotNetBrowser.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x64, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x64.2.0.0\lib\net45\DotNetBrowser.Chromium.Win-x64.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x86, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x86.2.0.0\lib\net45\DotNetBrowser.Chromium.Win-x86.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Core, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.0.0\lib\net45\DotNetBrowser.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Logging, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.0.0\lib\net45\DotNetBrowser.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/csharp/InjectObjectForScripting/Program.cs
+++ b/csharp/InjectObjectForScripting/Program.cs
@@ -1,0 +1,116 @@
+﻿#region Copyright
+
+// Copyright 2020, TeamDev. All rights reserved.
+// 
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using DotNetBrowser.Browser;
+using DotNetBrowser.Browser.Handlers;
+using DotNetBrowser.Engine;
+using DotNetBrowser.Geometry;
+using DotNetBrowser.Handlers;
+using DotNetBrowser.Js;
+
+namespace InjectObjectForScripting
+{
+    /// <summary>
+    ///     This example demonstrates how to use InjectJsHandler for injecting "window.external"
+    ///     object into the web page.
+    /// </summary>
+    internal class Program
+    {
+        #region Methods
+
+        private static void InjectObjectForScripting(InjectJsParameters p)
+        {
+            IJsObject window = p.Frame.ExecuteJavaScript<IJsObject>("window").Result;
+            window.Properties["external"] = ObjectForScripting.Instance;
+        }
+
+        private static void Main(string[] args)
+        {
+            try
+            {
+                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                {
+                    Console.WriteLine("Engine created");
+
+                    using (IBrowser browser = engine.CreateBrowser())
+                    {
+                        Console.WriteLine("Browser created");
+                        browser.Size = new Size(700, 500);
+                        browser.InjectJsHandler = new Handler<InjectJsParameters>(InjectObjectForScripting);
+                        browser.MainFrame.LoadHtml(@"<html>
+                                     <body>
+                                        <script type='text/javascript'>
+                                            var SetTitle = function () 
+                                            {
+                                                 document.title = window.external.GetTitle();
+                                            };
+                                        </script>
+                                     </body>
+                                   </html>")
+                               .Wait();
+
+                        browser.MainFrame.ExecuteJavaScript<IJsObject>("window.SetTitle();").Wait();
+
+                        Console.WriteLine($"\tBrowser title: {browser.Title}");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
+            Console.WriteLine("Press any key to terminate...");
+            Console.ReadKey();
+        }
+
+        #endregion
+
+        public sealed class ObjectForScripting
+        {
+            #region Properties
+
+            public static ObjectForScripting Instance { get; } = new ObjectForScripting();
+
+            #endregion
+
+            #region Constructors
+
+            static ObjectForScripting()
+            {
+            }
+
+            private ObjectForScripting()
+            {
+            }
+
+            #endregion
+
+            #region Methods
+
+            public string GetTitle() => "Document title from .NET";
+
+            #endregion
+        }
+    }
+}

--- a/csharp/InjectObjectForScripting/Properties/AssemblyInfo.cs
+++ b/csharp/InjectObjectForScripting/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("InjectObjectForScripting")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("InjectObjectForScripting")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6daa56fc-bff7-4916-a91e-64d71e2c0667")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp/InjectObjectForScripting/Properties/AssemblyInfo.cs
+++ b/csharp/InjectObjectForScripting/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("InjectObjectForScripting")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("TeamDev")]
 [assembly: AssemblyProduct("InjectObjectForScripting")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright © 2020, TeamDev. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/csharp/InjectObjectForScripting/packages.config
+++ b/csharp/InjectObjectForScripting/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetBrowser" version="2.0.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x64" version="2.0.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x86" version="2.0.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
+</packages>

--- a/vbnet/DotNetBrowser.Examples.sln
+++ b/vbnet/DotNetBrowser.Examples.sln
@@ -89,6 +89,8 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "SaveImageFromPage", "SaveIm
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "FullScreen.WinForms", "FullScreen.WinForms\FullScreen.WinForms.vbproj", "{CDD33926-0653-4AE0-A1CF-E6BA2606293D}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "InjectObjectForScripting", "InjectObjectForScripting\InjectObjectForScripting.vbproj", "{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -263,6 +265,10 @@ Global
 		{CDD33926-0653-4AE0-A1CF-E6BA2606293D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDD33926-0653-4AE0-A1CF-E6BA2606293D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDD33926-0653-4AE0-A1CF-E6BA2606293D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vbnet/InjectObjectForScripting/App.config
+++ b/vbnet/InjectObjectForScripting/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/vbnet/InjectObjectForScripting/InjectObjectForScripting.vbproj
+++ b/vbnet/InjectObjectForScripting/InjectObjectForScripting.vbproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6DAA56FC-BFF7-4916-A91E-64D71E2C0667}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>InjectObjectForScripting</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionCompare>Binary</OptionCompare>
+    <OptionStrict>Off</OptionStrict>
+    <OptionInfer>On</OptionInfer>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Import Include="Microsoft.VisualBasic" />
+    <Import Include="System.Collections.Generic" />
+    <Import Include="System.Collections" />
+    <Import Include="System.Diagnostics" />
+    <Import Include="System.Linq" />
+    <Import Include="System.Xml.Linq" />
+    <Import Include="System.Data" />
+    <Import Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="DotNetBrowser, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.0.0\lib\net45\DotNetBrowser.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x64, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x64.2.0.0\lib\net45\DotNetBrowser.Chromium.Win-x64.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x86, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x86.2.0.0\lib\net45\DotNetBrowser.Chromium.Win-x86.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Core, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.0.0\lib\net45\DotNetBrowser.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Logging, Version=2.0.0.1097, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.0.0\lib\net45\DotNetBrowser.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.vb" />
+    <Compile Include="My Project\AssemblyInfo.vb" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+</Project>

--- a/vbnet/InjectObjectForScripting/My Project/AssemblyInfo.vb
+++ b/vbnet/InjectObjectForScripting/My Project/AssemblyInfo.vb
@@ -1,0 +1,36 @@
+﻿Imports System.Reflection
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+' General Information about an assembly is controlled through the following
+' set of attributes. Change these attribute values to modify the information
+' associated with an assembly.
+<Assembly: AssemblyTitle("InjectObjectForScripting")>
+<Assembly: AssemblyDescription("")>
+<Assembly: AssemblyConfiguration("")>
+<Assembly: AssemblyCompany("TeamDev")>
+<Assembly: AssemblyProduct("InjectObjectForScripting")>
+<Assembly: AssemblyCopyright("Copyright © 2020, TeamDev. All rights reserved.")>
+<Assembly: AssemblyTrademark("")>
+<Assembly: AssemblyCulture("")>
+
+' Setting ComVisible to false makes the types in this assembly not visible
+' to COM components.  If you need to access a type in this assembly from
+' COM, set the ComVisible attribute to true on that type.
+<Assembly: ComVisible(False)>
+
+' The following GUID is for the ID of the typelib if this project is exposed to COM
+<Assembly: Guid("6daa56fc-bff7-4916-a91e-64d71e2c0667")>
+
+' Version information for an assembly consists of the following four values:
+'
+'      Major Version
+'      Minor Version
+'      Build Number
+'      Revision
+'
+' You can specify all the values or you can default the Build and Revision Numbers
+' by using the '*' as shown below:
+' [assembly: AssemblyVersion("1.0.*")]
+<Assembly: AssemblyVersion("1.0.0.0")>
+<Assembly: AssemblyFileVersion("1.0.0.0")>

--- a/vbnet/InjectObjectForScripting/Program.vb
+++ b/vbnet/InjectObjectForScripting/Program.vb
@@ -1,0 +1,105 @@
+﻿#Region "Copyright"
+
+' Copyright 2020, TeamDev. All rights reserved.
+' 
+' Redistribution and use in source and/or binary forms, with or without
+' modification, must retain the above copyright notice and the following
+' disclaimer.
+' 
+' THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+' "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+' LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+' A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+' OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+' SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+' LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+' DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+' THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+' (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#End Region
+
+Imports System
+Imports DotNetBrowser.Browser
+Imports DotNetBrowser.Browser.Handlers
+Imports DotNetBrowser.Engine
+Imports DotNetBrowser.Geometry
+Imports DotNetBrowser.Handlers
+Imports DotNetBrowser.Js
+
+Namespace InjectObjectForScripting
+	''' <summary>
+	'''     This example demonstrates how to use InjectJsHandler for injecting "window.external"
+	'''     object into the web page.
+	''' </summary>
+	Friend Class Program
+		#Region "Methods"
+
+		Private Shared Sub InjectObjectForScripting(ByVal p As InjectJsParameters)
+			Dim window As IJsObject = p.Frame.ExecuteJavaScript(Of IJsObject)("window").Result
+			window.Properties("external") = ObjectForScripting.Instance
+		End Sub
+
+		Public Shared Sub Main(ByVal args() As String)
+			Try
+				Using engine As IEngine = EngineFactory.Create((New EngineOptions.Builder()).Build())
+					Console.WriteLine("Engine created")
+
+					Using browser As IBrowser = engine.CreateBrowser()
+						Console.WriteLine("Browser created")
+						browser.Size = New Size(700, 500)
+						browser.InjectJsHandler = New Handler(Of InjectJsParameters)(AddressOf InjectObjectForScripting)
+						browser.MainFrame.LoadHtml("<html>
+                                     <body>
+                                        <script type='text/javascript'>
+                                            var SetTitle = function () 
+                                            {
+                                                 document.title = window.external.GetTitle();
+                                            };
+                                        </script>
+                                     </body>
+                                   </html>").Wait()
+
+						browser.MainFrame.ExecuteJavaScript(Of IJsObject)("window.SetTitle();").Wait()
+
+						Console.WriteLine(vbTab & "Browser title: " & browser.Title)
+					End Using
+				End Using
+			Catch e As Exception
+				Console.WriteLine(e)
+			End Try
+
+			Console.WriteLine("Press any key to terminate...")
+			Console.ReadKey()
+		End Sub
+
+		#End Region
+
+		Public NotInheritable Class ObjectForScripting
+			#Region "Properties"
+
+			Public Shared ReadOnly Property Instance() As New ObjectForScripting()
+
+			#End Region
+
+			#Region "Constructors"
+
+			Shared Sub New()
+			End Sub
+
+			Private Sub New()
+			End Sub
+
+			#End Region
+
+			#Region "Methods"
+
+			Public Function GetTitle() As String
+				Return "Document title from .NET"
+			End Function
+
+			#End Region
+		End Class
+	End Class
+End Namespace

--- a/vbnet/InjectObjectForScripting/packages.config
+++ b/vbnet/InjectObjectForScripting/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetBrowser" version="2.0.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x64" version="2.0.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x86" version="2.0.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This PR adds an example that demonstrates how to use `InjectJsHandler` to simulate `window.external` presence.