### PR TITLE
Add application domains examples

### DIFF
--- a/csharp/DotNetBrowser.Examples.sln
+++ b/csharp/DotNetBrowser.Examples.sln
@@ -123,6 +123,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevTools.WinForms", "DevToo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JavaScriptBridge.Arrays", "JavaScriptBridge.Arrays\JavaScriptBridge.Arrays.csproj", "{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeparateEngines.AppDomains", "SeparateEngines.AppDomains\SeparateEngines.AppDomains.csproj", "{9C77DF2B-CF88-460D-8E8C-0084C56872F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -365,6 +367,10 @@ Global
 		{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/SeparateEngines.AppDomains/App.config
+++ b/csharp/SeparateEngines.AppDomains/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/csharp/SeparateEngines.AppDomains/Program.cs
+++ b/csharp/SeparateEngines.AppDomains/Program.cs
@@ -1,0 +1,154 @@
+﻿#region Copyright
+
+// Copyright 2020, TeamDev. All rights reserved.
+// 
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading;
+using DotNetBrowser.Browser;
+using DotNetBrowser.Engine;
+using DotNetBrowser.Geometry;
+
+namespace SeparateEngines.AppDomains
+{
+    /// <summary>
+    ///     This example demonstrates how to create and use separate IEngine instances
+    ///     in different application domains.
+    /// </summary>
+    internal class Program
+    {
+        #region Methods
+
+        private static void Main(string[] args)
+        {
+            // Create two separate application domains.
+            AppDomain domain1 = AppDomain.CreateDomain("Domain1");
+            AppDomain domain2 = AppDomain.CreateDomain("Domain2");
+
+            try
+            {
+                // Create an instance of EngineWrapper in the first AppDomain.
+                // A proxy to the object is returned.
+                Console.WriteLine("Create wrapper1");
+                EngineWrapper wrapper1 = (EngineWrapper)
+                    domain1.CreateInstanceAndUnwrap(typeof(EngineWrapper).Assembly.FullName,
+                                                    typeof(EngineWrapper).FullName);
+
+                // Create an instance of EngineWrapper in the second AppDomain.
+                // A proxy to the object is returned.
+                Console.WriteLine("Create wrapper2");
+                EngineWrapper wrapper2 = (EngineWrapper)
+                    domain2.CreateInstanceAndUnwrap(typeof(EngineWrapper).Assembly.FullName,
+                                                    typeof(EngineWrapper).FullName);
+
+                //Execute an action in the first application domain.
+                string title1 = wrapper1.LoadAndGetTitle("teamdev.com");
+                Console.WriteLine("Title 1: {0}", title1);
+
+                //Dispose the wrapper and unload the first application domain.
+                Console.WriteLine("Dispose wrapper1");
+                wrapper1.Dispose();
+                AppDomain.Unload(domain1);
+
+                //After unloading the first domain, the engine in the second domain is alive, and we can execute actions.
+                string title2 = wrapper2.LoadAndGetTitle("teamdev.com/dotnetbrowser");
+                Console.WriteLine("Title 2: {0}", title2);
+
+                //Dispose the wrapper and unload the second application domain.
+                Console.WriteLine("Dispose wrapper2");
+                wrapper2.Dispose();
+                AppDomain.Unload(domain2);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
+            Console.WriteLine("Press any key to terminate...");
+            Console.ReadKey();
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    ///     This class serves as a wrapper for DotNetBrowser objects and the logic related to these objects,
+    ///     since they cannot be marshaled directly.
+    /// </summary>
+    internal class EngineWrapper : MarshalByRefObject, IDisposable
+    {
+        #region Properties
+
+        private IEngine Engine { get; }
+
+        #endregion
+
+        #region Constructors
+
+        public EngineWrapper()
+        {
+            //Perform complex engine initialization here if necessary.
+            Engine = EngineFactory.Create();
+        }
+
+        #endregion
+
+        #region Methods
+
+        public void Dispose()
+        {
+            Engine?.Dispose();
+        }
+
+        /// <summary>
+        ///     This method demonstrates how to implement a particular scenario that
+        ///     should be performed in a separate application domain.
+        ///     <para>
+        ///         For instance, this method returns a web page title after loading that web page completely.
+        ///     </para>
+        /// </summary>
+        /// <param name="url">The URL to load.</param>
+        /// <returns>The title of the loaded web page.</returns>
+        public string LoadAndGetTitle(string url)
+        {
+            string result = null;
+            Console.WriteLine("Loading URL '{0}' in '{1}'.", url, Thread.GetDomain().FriendlyName);
+            try
+            {
+                using (IBrowser browser = Engine.CreateBrowser())
+                {
+                    Console.WriteLine("Browser created");
+                    browser.Size = new Size(700, 500);
+                    browser.Navigation.LoadUrl(url).Wait();
+                    Console.WriteLine("URL loaded");
+                    result = browser.Title;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
+            return result;
+        }
+
+        #endregion
+    }
+}

--- a/csharp/SeparateEngines.AppDomains/Program.cs
+++ b/csharp/SeparateEngines.AppDomains/Program.cs
@@ -121,7 +121,8 @@ namespace SeparateEngines.AppDomains
         ///     This method demonstrates how to implement a particular scenario that
         ///     should be performed in a separate application domain.
         ///     <para>
-        ///         For instance, this method returns a web page title after loading that web page completely.
+        ///         For instance, this method returns a web page title after loading that web page completely
+        ///         in a separate browser instance.
         ///     </para>
         /// </summary>
         /// <param name="url">The URL to load.</param>

--- a/csharp/SeparateEngines.AppDomains/Program.cs
+++ b/csharp/SeparateEngines.AppDomains/Program.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright
 
-// Copyright 2020, TeamDev. All rights reserved.
+// Copyright 2021, TeamDev. All rights reserved.
 // 
 // Redistribution and use in source and/or binary forms, with or without
 // modification, must retain the above copyright notice and the following

--- a/csharp/SeparateEngines.AppDomains/Properties/AssemblyInfo.cs
+++ b/csharp/SeparateEngines.AppDomains/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SeparateEngines.AppDomains")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SeparateEngines.AppDomains")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9c77df2b-cf88-460d-8e8c-0084c56872f6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/csharp/SeparateEngines.AppDomains/Properties/AssemblyInfo.cs
+++ b/csharp/SeparateEngines.AppDomains/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("SeparateEngines.AppDomains")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("TeamDev")]
 [assembly: AssemblyProduct("SeparateEngines.AppDomains")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright © 2021, TeamDev. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/csharp/SeparateEngines.AppDomains/SeparateEngines.AppDomains.csproj
+++ b/csharp/SeparateEngines.AppDomains/SeparateEngines.AppDomains.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9C77DF2B-CF88-460D-8E8C-0084C56872F6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SeparateEngines.AppDomains</RootNamespace>
+    <AssemblyName>SeparateEngines.AppDomains</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="DotNetBrowser, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.3.0\lib\net45\DotNetBrowser.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x64, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x64.2.3.0\lib\net45\DotNetBrowser.Chromium.Win-x64.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x86, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x86.2.3.0\lib\net45\DotNetBrowser.Chromium.Win-x86.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Core, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.3.0\lib\net45\DotNetBrowser.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Logging, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.3.0\lib\net45\DotNetBrowser.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/csharp/SeparateEngines.AppDomains/packages.config
+++ b/csharp/SeparateEngines.AppDomains/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetBrowser" version="2.3.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x64" version="2.3.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x86" version="2.3.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
+</packages>

--- a/csharp/SeparateEngines/Properties/AssemblyInfo.cs
+++ b/csharp/SeparateEngines/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("SeparateEngines")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("TeamDev")]
 [assembly: AssemblyProduct("SeparateEngines")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright © 2021, TeamDev. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/csharp/TransparentWebPage.Wpf/Properties/AssemblyInfo.cs
+++ b/csharp/TransparentWebPage.Wpf/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("TeamDev")]
 [assembly: AssemblyProduct("TransparentWebPage.Wpf")]
-[assembly: AssemblyCopyright("Copyright © 2020, TeamDev. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © 2021, TeamDev. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/vbnet/DotNetBrowser.Examples.sln
+++ b/vbnet/DotNetBrowser.Examples.sln
@@ -123,6 +123,8 @@ Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "DevTools.WinForms", "DevToo
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "JavaScriptBridge.Arrays", "JavaScriptBridge.Arrays\JavaScriptBridge.Arrays.vbproj", "{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "SeparateEngines.AppDomains", "SeparateEngines.AppDomains\SeparateEngines.AppDomains.vbproj", "{9C77DF2B-CF88-460D-8E8C-0084C56872F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -365,6 +367,10 @@ Global
 		{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DEA511E-8F90-4E8C-AA36-EC70523E2C12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C77DF2B-CF88-460D-8E8C-0084C56872F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vbnet/SeparateEngines.AppDomains/App.config
+++ b/vbnet/SeparateEngines.AppDomains/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/vbnet/SeparateEngines.AppDomains/My Project/AssemblyInfo.vb
+++ b/vbnet/SeparateEngines.AppDomains/My Project/AssemblyInfo.vb
@@ -1,0 +1,36 @@
+﻿Imports System.Reflection
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+' General Information about an assembly is controlled through the following
+' set of attributes. Change these attribute values to modify the information
+' associated with an assembly.
+<Assembly: AssemblyTitle("SeparateEngines.AppDomains")>
+<Assembly: AssemblyDescription("")>
+<Assembly: AssemblyConfiguration("")>
+<Assembly: AssemblyCompany("TeamDev")>
+<Assembly: AssemblyProduct("SeparateEngines.AppDomains")>
+<Assembly: AssemblyCopyright("Copyright © 2021, TeamDev. All rights reserved.")>
+<Assembly: AssemblyTrademark("")>
+<Assembly: AssemblyCulture("")>
+
+' Setting ComVisible to false makes the types in this assembly not visible
+' to COM components.  If you need to access a type in this assembly from
+' COM, set the ComVisible attribute to true on that type.
+<Assembly: ComVisible(False)>
+
+' The following GUID is for the ID of the typelib if this project is exposed to COM
+<Assembly: Guid("9c77df2b-cf88-460d-8e8c-0084c56872f6")>
+
+' Version information for an assembly consists of the following four values:
+'
+'      Major Version
+'      Minor Version
+'      Build Number
+'      Revision
+'
+' You can specify all the values or you can default the Build and Revision Numbers
+' by using the '*' as shown below:
+' [assembly: AssemblyVersion("1.0.*")]
+<Assembly: AssemblyVersion("1.0.0.0")>
+<Assembly: AssemblyFileVersion("1.0.0.0")>

--- a/vbnet/SeparateEngines.AppDomains/Program.vb
+++ b/vbnet/SeparateEngines.AppDomains/Program.vb
@@ -1,0 +1,139 @@
+﻿#Region "Copyright"
+
+' Copyright 2021, TeamDev. All rights reserved.
+' 
+' Redistribution and use in source and/or binary forms, with or without
+' modification, must retain the above copyright notice and the following
+' disclaimer.
+' 
+' THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+' "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+' LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+' A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+' OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+' SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+' LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+' DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+' THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+' (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#End Region
+
+Imports System.Threading
+Imports DotNetBrowser.Browser
+Imports DotNetBrowser.Engine
+Imports DotNetBrowser.Geometry
+
+Namespace SeparateEngines.AppDomains
+	''' <summary>
+	'''     This example demonstrates how to create and use separate IEngine instances
+	'''     in different application domains.
+	''' </summary>
+	Friend Class Program
+		#Region "Methods"
+
+		Public Shared Sub Main(ByVal args() As String)
+			' Create two separate application domains.
+			Dim domain1 As AppDomain = AppDomain.CreateDomain("Domain1")
+			Dim domain2 As AppDomain = AppDomain.CreateDomain("Domain2")
+
+			Try
+				' Create an instance of EngineWrapper in the first AppDomain.
+				' A proxy to the object is returned.
+				Console.WriteLine("Create wrapper1")
+				Dim wrapper1 As EngineWrapper = DirectCast(domain1.CreateInstanceAndUnwrap(GetType(EngineWrapper).Assembly.FullName, GetType(EngineWrapper).FullName), EngineWrapper)
+
+				' Create an instance of EngineWrapper in the second AppDomain.
+				' A proxy to the object is returned.
+				Console.WriteLine("Create wrapper2")
+				Dim wrapper2 As EngineWrapper = DirectCast(domain2.CreateInstanceAndUnwrap(GetType(EngineWrapper).Assembly.FullName, GetType(EngineWrapper).FullName), EngineWrapper)
+
+				'Execute an action in the first application domain.
+				Dim title1 As String = wrapper1.LoadAndGetTitle("teamdev.com")
+				Console.WriteLine("Title 1: {0}", title1)
+
+				'Dispose the wrapper and unload the first application domain.
+				Console.WriteLine("Dispose wrapper1")
+				wrapper1.Dispose()
+				AppDomain.Unload(domain1)
+
+				'After unloading the first domain, the engine in the second domain is alive, and we can execute actions.
+				Dim title2 As String = wrapper2.LoadAndGetTitle("teamdev.com/dotnetbrowser")
+				Console.WriteLine("Title 2: {0}", title2)
+
+				'Dispose the wrapper and unload the second application domain.
+				Console.WriteLine("Dispose wrapper2")
+				wrapper2.Dispose()
+				AppDomain.Unload(domain2)
+			Catch e As Exception
+				Console.WriteLine(e)
+			End Try
+
+			Console.WriteLine("Press any key to terminate...")
+			Console.ReadKey()
+		End Sub
+
+		#End Region
+	End Class
+
+	''' <summary>
+	'''     This class serves as a wrapper for DotNetBrowser objects and the logic related to these objects,
+	'''     since they cannot be marshaled directly.
+	''' </summary>
+	Friend Class EngineWrapper
+		Inherits MarshalByRefObject
+		Implements IDisposable
+
+		#Region "Properties"
+
+		Private ReadOnly Property Engine() As IEngine
+
+		#End Region
+
+		#Region "Constructors"
+
+		Public Sub New()
+			'Perform complex engine initialization here if necessary.
+			Engine = EngineFactory.Create()
+		End Sub
+
+		#End Region
+
+		#Region "Methods"
+
+		Public Sub Dispose() Implements IDisposable.Dispose
+			Engine?.Dispose()
+		End Sub
+
+		''' <summary>
+		'''     This method demonstrates how to implement a particular scenario that
+		'''     should be performed in a separate application domain.
+		'''     <para>
+		'''         For instance, this method returns a web page title after loading that web page completely
+		'''         in a separate browser instance.
+		'''     </para>
+		''' </summary>
+		''' <param name="url">The URL to load.</param>
+		''' <returns>The title of the loaded web page.</returns>
+		Public Function LoadAndGetTitle(ByVal url As String) As String
+			Dim result As String = Nothing
+			Console.WriteLine("Loading URL '{0}' in '{1}'.", url, Thread.GetDomain().FriendlyName)
+			Try
+				Using browser As IBrowser = Engine.CreateBrowser()
+					Console.WriteLine("Browser created")
+					browser.Size = New Size(700, 500)
+					browser.Navigation.LoadUrl(url).Wait()
+					Console.WriteLine("URL loaded")
+					result = browser.Title
+				End Using
+			Catch e As Exception
+				Console.WriteLine(e)
+			End Try
+
+			Return result
+		End Function
+
+		#End Region
+	End Class
+End Namespace

--- a/vbnet/SeparateEngines.AppDomains/SeparateEngines.AppDomains.vbproj
+++ b/vbnet/SeparateEngines.AppDomains/SeparateEngines.AppDomains.vbproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9C77DF2B-CF88-460D-8E8C-0084C56872F6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>SeparateEngines.AppDomains</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionCompare>Binary</OptionCompare>
+    <OptionStrict>Off</OptionStrict>
+    <OptionInfer>On</OptionInfer>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <ErrorReport>prompt</ErrorReport>
+    <RemoveIntegerChecks>true</RemoveIntegerChecks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <ErrorReport>prompt</ErrorReport>
+    <RemoveIntegerChecks>true</RemoveIntegerChecks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Import Include="Microsoft.VisualBasic" />
+    <Import Include="System" />
+    <Import Include="System.Collections" />
+    <Import Include="System.Collections.Generic" />
+    <Import Include="System.Diagnostics" />
+    <Import Include="System.Linq" />
+    <Import Include="System.Xml.Linq" />
+    <Import Include="System.Threading.Tasks" />
+    <Import Include="System.Data" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="DotNetBrowser, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.3.0\lib\net45\DotNetBrowser.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x64, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x64.2.3.0\lib\net45\DotNetBrowser.Chromium.Win-x64.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Chromium.Win-x86, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.Chromium.Win-x86.2.3.0\lib\net45\DotNetBrowser.Chromium.Win-x86.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Core, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.3.0\lib\net45\DotNetBrowser.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetBrowser.Logging, Version=2.3.0.1362, Culture=neutral, PublicKeyToken=b0b5aaca9c95c84e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetBrowser.2.3.0\lib\net45\DotNetBrowser.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.vb" />
+    <Compile Include="My Project\AssemblyInfo.vb" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+</Project>

--- a/vbnet/SeparateEngines.AppDomains/packages.config
+++ b/vbnet/SeparateEngines.AppDomains/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DotNetBrowser" version="2.3.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x64" version="2.3.0" targetFramework="net45" />
+  <package id="DotNetBrowser.Chromium.Win-x86" version="2.3.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This PR adds C# and VB.NET examples demonstrating how to use separate `IEngine` instances in separate application domains.