### PR TITLE
Update JavaScriptBridge.Promises example

### DIFF
--- a/csharp/JavaScriptBridge.Promises/JavaScriptBridge.Promises.csproj
+++ b/csharp/JavaScriptBridge.Promises/JavaScriptBridge.Promises.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="JsPromise.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/csharp/JavaScriptBridge.Promises/JsPromise.cs
+++ b/csharp/JavaScriptBridge.Promises/JsPromise.cs
@@ -1,0 +1,177 @@
+﻿#region Copyright
+
+// Copyright 2021, TeamDev. All rights reserved.
+// 
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using DotNetBrowser.Js;
+
+namespace JavaScriptBridge.Promises
+{
+    public static class JsObjectExtensions
+    {
+        #region Methods
+
+        public static JsPromise AsPromise(this IJsObject jsObject) => JsPromise.AsPromise(jsObject);
+
+        #endregion
+    }
+
+    /// <summary>
+    ///     An example of a wrapper for IJsObject that simplifies handling JavaScript promises.
+    /// </summary>
+    public sealed class JsPromise
+    {
+        private readonly IJsObject jsObject;
+
+        #region Constructors
+
+        private JsPromise(IJsObject jsObject)
+        {
+            this.jsObject = jsObject;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        ///     Creates a JavaScript promise representation of the IJsObject instance.
+        /// </summary>
+        /// <param name="jsObject">The JavaScript object.</param>
+        /// <returns>The JsPromise representation of the object.</returns>
+        public static JsPromise AsPromise(IJsObject jsObject) => !IsPromise(jsObject) ? null : new JsPromise(jsObject);
+
+        /// <summary>
+        ///     Appends a rejection handler callback to the promise, and returns a new <see cref="JsPromise" />
+        ///     resolving to the return value of the callback if it is called, or to its original fulfillment
+        ///     value if the promise is instead fulfilled.
+        /// </summary>
+        /// <param name="onRejected">The rejection handler.</param>
+        /// <returns>A new <see cref="JsPromise" /></returns>
+        public JsPromise Catch(Func<object, object> onRejected)
+        {
+            IJsObject newPromise = jsObject.Invoke("catch", onRejected) as IJsObject;
+            return new JsPromise(newPromise);
+        }
+
+        /// <summary>
+        ///     Appends fulfillment and rejection handlers to the promise, and returns a <c>Task</c>
+        ///     that becomes completed as soon as the promise is resolved.
+        /// </summary>
+        /// <returns>
+        ///     a <c>Task</c> that becomes completed as soon as any of these handlers is called.
+        /// </returns>
+        public Task<Result> ResolveAsync()
+        {
+            TaskCompletionSource<Result> promiseTcs = new TaskCompletionSource<Result>();
+            Then(obj => { promiseTcs.TrySetResult(Fulfilled(obj)); },
+                 obj => { promiseTcs.TrySetResult(Rejected(obj)); });
+
+            promiseTcs.Task.ConfigureAwait(false);
+            return promiseTcs.Task;
+        }
+
+        /// <summary>
+        ///     Appends fulfillment and rejection handlers to the promise.
+        /// </summary>
+        /// <param name="onFulfilled"> The fulfillment handler.</param>
+        /// <param name="onRejected">The rejection handler.</param>
+        public void Then(Action<object> onFulfilled, Action<object> onRejected = null)
+        {
+            jsObject.Invoke("then", onFulfilled, onRejected);
+        }
+
+        /// <summary>
+        ///     Appends fulfillment and rejection handlers to the promise, and returns a new <see cref="JsPromise" />
+        ///     resolving to the return value of the called handler, or to its original settled value
+        ///     if the promise was not handled.
+        /// </summary>
+        /// <param name="onFulfilled"> The fulfillment handler.</param>
+        /// <param name="onRejected">The rejection handler.</param>
+        /// <returns>A new <see cref="JsPromise" /></returns>
+        public JsPromise Then(Func<object, object> onFulfilled, Func<object, object> onRejected = null)
+        {
+            IJsObject newPromise = jsObject.Invoke("then", onFulfilled, onRejected) as IJsObject;
+            return new JsPromise(newPromise);
+        }
+
+        private Result Fulfilled(object o) => new Result(ResultState.Fulfilled, o);
+
+        private static bool IsPromise(IJsObject jsObject)
+        {
+            if (jsObject == null || jsObject.IsDisposed)
+            {
+                return false;
+            }
+
+            IJsObject promisePrototype = jsObject.Frame.ExecuteJavaScript<IJsObject>("Promise.prototype").Result;
+            return promisePrototype.Invoke<bool>("isPrototypeOf", jsObject);
+        }
+
+        private Result Rejected(object o) => new Result(ResultState.Rejected, o);
+
+        #endregion
+
+        /// <summary>
+        ///     The Promise result state.
+        /// </summary>
+        public enum ResultState
+        {
+            /// <summary>
+            ///     The Promise was fulfilled.
+            /// </summary>
+            Fulfilled,
+
+            /// <summary>
+            ///     The promise was rejected.
+            /// </summary>
+            Rejected
+        }
+
+        public class Result
+        {
+            #region Properties
+
+            /// <summary>
+            ///     The object passed to the fulfillment or rejection handler.
+            /// </summary>
+            public object Data { get; }
+
+            /// <summary>
+            ///     The promise result state that indicates whether the promise was fulfilled or rejected.
+            /// </summary>
+            public ResultState State { get; }
+
+            #endregion
+
+            #region Constructors
+
+            internal Result(ResultState state, object data)
+            {
+                State = state;
+                Data = data;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/csharp/JavaScriptBridge.Promises/Program.cs
+++ b/csharp/JavaScriptBridge.Promises/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
 using DotNetBrowser.Geometry;
@@ -82,6 +83,8 @@ namespace JavaScriptBridge.Promises
                         IJsObject promise2 = window.Invoke<IJsObject>("CreatePromise", false);
                         //Append fulfillment and rejection handlers to the promise
                         promise2.Invoke("then", promiseResolvedHandler, promiseRejectedHandler);
+
+                        CreatePromiseAsync(window).Wait();
                     }
                 }
             }
@@ -92,6 +95,33 @@ namespace JavaScriptBridge.Promises
 
             Console.WriteLine("Press any key to terminate...");
             Console.ReadKey();
+        }
+
+        private static async Task CreatePromiseAsync(IJsObject window)
+        {
+            //It is also possible to create a wrapper class for IJsObject that simplifies appending the
+            //handlers and type checks. Such approach can be used to integrate JavaScript promises
+            //with async/await in the .NET application.
+
+            //Create a promise that is fulfilled and wrap this promise
+            Console.WriteLine("\nCreate another promise that is fulfilled...");
+            JsPromise promise3 = window.Invoke<IJsObject>("CreatePromise", true).AsPromise();
+            JsPromise.Result result = await promise3.Then(o =>
+                                                {
+                                                    Console.WriteLine("Callback:Success: " + o);
+                                                    return o;
+                                                })
+                                               .ResolveAsync();
+            Console.WriteLine("Result state:" + result?.State);
+            Console.WriteLine("Result type:" + (result?.Data?.GetType().ToString() ?? "null"));
+
+            //Create a promise that is rejected and wrap this promise
+            Console.WriteLine("\nCreate another promise that is rejected...");
+            JsPromise promise4 = window.Invoke<IJsObject>("CreatePromise", false).AsPromise();
+            result = await promise4.ResolveAsync();
+
+            Console.WriteLine("Result state:" + result?.State);
+            Console.WriteLine("Result type:" + (result?.Data?.GetType().ToString() ?? "null"));
         }
 
         #endregion

--- a/vbnet/JavaScriptBridge.Promises/JavaScriptBridge.Promises.vbproj
+++ b/vbnet/JavaScriptBridge.Promises/JavaScriptBridge.Promises.vbproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -81,6 +81,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="JsPromise.vb" />
     <Compile Include="Program.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
   </ItemGroup>

--- a/vbnet/JavaScriptBridge.Promises/JsPromise.vb
+++ b/vbnet/JavaScriptBridge.Promises/JsPromise.vb
@@ -1,0 +1,174 @@
+﻿#Region "Copyright"
+
+' Copyright 2021, TeamDev. All rights reserved.
+' 
+' Redistribution and use in source and/or binary forms, with or without
+' modification, must retain the above copyright notice and the following
+' disclaimer.
+' 
+' THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+' "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+' LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+' A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+' OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+' SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+' LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+' DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+' THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+' (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#End Region
+
+Imports DotNetBrowser.Js
+
+Namespace JavaScriptBridge.Promises
+	Public Module JsObjectExtensions
+		#Region "Methods"
+
+		<System.Runtime.CompilerServices.Extension> _
+		Public Function AsPromise(ByVal jsObject As IJsObject) As JsPromise
+			Return JsPromise.AsPromise(jsObject)
+		End Function
+
+		#End Region
+	End Module
+
+	''' <summary>
+	'''     An example of a wrapper for IJsObject that simplifies handling JavaScript promises.
+	''' </summary>
+	Public NotInheritable Class JsPromise
+		Private ReadOnly jsObject As IJsObject
+
+		#Region "Constructors"
+
+		Private Sub New(ByVal jsObject As IJsObject)
+			Me.jsObject = jsObject
+		End Sub
+
+		#End Region
+
+		#Region "Methods"
+
+		''' <summary>
+		'''     Creates a JavaScript promise representation of the IJsObject instance.
+		''' </summary>
+		''' <param name="jsObject">The JavaScript object.</param>
+		''' <returns>The JsPromise representation of the object.</returns>
+		Public Shared Function AsPromise(ByVal jsObject As IJsObject) As JsPromise
+			Return If(Not IsPromise(jsObject), Nothing, New JsPromise(jsObject))
+		End Function
+
+		''' <summary>
+		'''     Appends a rejection handler callback to the promise, and returns a new <see cref="JsPromise" />
+		'''     resolving to the return value of the callback if it is called, or to its original fulfillment
+		'''     value if the promise is instead fulfilled.
+		''' </summary>
+		''' <param name="onRejected">The rejection handler.</param>
+		''' <returns>A new <see cref="JsPromise" /></returns>
+		Public Function [Catch](ByVal onRejected As Func(Of Object, Object)) As JsPromise
+			Dim newPromise As IJsObject = TryCast(jsObject.Invoke("catch", onRejected), IJsObject)
+			Return New JsPromise(newPromise)
+		End Function
+
+		''' <summary>
+		'''     Appends fulfillment and rejection handlers to the promise, and returns a <c>Task</c>
+		'''     that becomes completed as soon as the promise is resolved.
+		''' </summary>
+		''' <returns>
+		'''     a <c>Task</c> that becomes completed as soon as any of these handlers is called.
+		''' </returns>
+		Public Function ResolveAsync() As Task(Of Result)
+			Dim promiseTcs As New TaskCompletionSource(Of Result)()
+			[Then](Sub(obj)
+				promiseTcs.TrySetResult(Fulfilled(obj))
+			End Sub, Sub(obj)
+				promiseTcs.TrySetResult(Rejected(obj))
+			End Sub)
+
+			promiseTcs.Task.ConfigureAwait(False)
+			Return promiseTcs.Task
+		End Function
+
+		''' <summary>
+		'''     Appends fulfillment and rejection handlers to the promise.
+		''' </summary>
+		''' <param name="onFulfilled"> The fulfillment handler.</param>
+		''' <param name="onRejected">The rejection handler.</param>
+		Public Sub [Then](ByVal onFulfilled As Action(Of Object), Optional ByVal onRejected As Action(Of Object) = Nothing)
+			jsObject.Invoke("then", onFulfilled, onRejected)
+		End Sub
+
+		''' <summary>
+		'''     Appends fulfillment and rejection handlers to the promise, and returns a new <see cref="JsPromise" />
+		'''     resolving to the return value of the called handler, or to its original settled value
+		'''     if the promise was not handled.
+		''' </summary>
+		''' <param name="onFulfilled"> The fulfillment handler.</param>
+		''' <param name="onRejected">The rejection handler.</param>
+		''' <returns>A new <see cref="JsPromise" /></returns>
+		Public Function [Then](ByVal onFulfilled As Func(Of Object, Object), Optional ByVal onRejected As Func(Of Object, Object) = Nothing) As JsPromise
+			Dim newPromise As IJsObject = TryCast(jsObject.Invoke("then", onFulfilled, onRejected), IJsObject)
+			Return New JsPromise(newPromise)
+		End Function
+
+		Private Function Fulfilled(ByVal o As Object) As Result
+			Return New Result(ResultState.Fulfilled, o)
+		End Function
+
+		Private Shared Function IsPromise(ByVal jsObject As IJsObject) As Boolean
+			If jsObject Is Nothing OrElse jsObject.IsDisposed Then
+				Return False
+			End If
+
+			Dim promisePrototype As IJsObject = jsObject.Frame.ExecuteJavaScript(Of IJsObject)("Promise.prototype").Result
+			Return promisePrototype.Invoke(Of Boolean)("isPrototypeOf", jsObject)
+		End Function
+
+		Private Function Rejected(ByVal o As Object) As Result
+			Return New Result(ResultState.Rejected, o)
+		End Function
+
+		#End Region
+
+		''' <summary>
+		'''     The Promise result state.
+		''' </summary>
+		Public Enum ResultState
+			''' <summary>
+			'''     The Promise was fulfilled.
+			''' </summary>
+			Fulfilled
+
+			''' <summary>
+			'''     The promise was rejected.
+			''' </summary>
+			Rejected
+		End Enum
+
+		Public Class Result
+			#Region "Properties"
+
+			''' <summary>
+			'''     The object passed to the fulfillment or rejection handler.
+			''' </summary>
+			Public ReadOnly Property Data() As Object
+
+			''' <summary>
+			'''     The promise result state that indicates whether the promise was fulfilled or rejected.
+			''' </summary>
+			Public ReadOnly Property State() As ResultState
+
+			#End Region
+
+			#Region "Constructors"
+
+			Friend Sub New(ByVal promiseState As ResultState, ByVal promiseData As Object)
+				Me.State = promiseState
+				Me.Data = promiseData
+			End Sub
+
+			#End Region
+		End Class
+	End Class
+End Namespace

--- a/vbnet/JavaScriptBridge.Promises/Program.vb
+++ b/vbnet/JavaScriptBridge.Promises/Program.vb
@@ -24,6 +24,7 @@ Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.Geometry
 Imports DotNetBrowser.Js
+Imports JavaScriptBridge.Promises
 
 ''' <summary>
 '''     This example demonstrates how to work with JavaScript Promises
@@ -73,6 +74,8 @@ Friend Class Program
                     Dim promise2 = window.Invoke(Of IJsObject)("CreatePromise", False)
                     'Append fulfillment and rejection handlers to the promise
                     promise2.Invoke("then", promiseResolvedHandler, promiseRejectedHandler)
+
+                    CreatePromiseAsync(window).Wait()
                 End Using
             End Using
         Catch e As Exception
@@ -82,6 +85,30 @@ Friend Class Program
         Console.WriteLine("Press any key to terminate...")
         Console.ReadKey()
     End Sub
+
+    Private Shared Async Function CreatePromiseAsync(ByVal window As IJsObject) As Task
+        'It is also possible to create a wrapper class for IJsObject that simplifies appending the
+        'handlers and type checks. Such approach can be used to integrate JavaScript promises
+        'with async/await in the .NET application.
+
+        'Create a promise that is fulfilled and wrap this promise
+        Console.WriteLine(vbLf & "Create another promise that is fulfilled...")
+        Dim promise3 As JsPromise = window.Invoke(Of IJsObject)("CreatePromise", True).AsPromise()
+        Dim result As JsPromise.Result = Await promise3.Then(Function(o)
+            Console.WriteLine("Callback:Success: " & o)
+            Return o
+        End Function).ResolveAsync()
+        Console.WriteLine("Result state:" & result?.State.ToString())
+        Console.WriteLine("Result type:" & (If(result?.Data?.GetType().ToString(), "null")))
+
+        'Create a promise that is rejected and wrap this promise
+        Console.WriteLine(vbLf & "Create another promise that is rejected...")
+        Dim promise4 As JsPromise = window.Invoke(Of IJsObject)("CreatePromise", False).AsPromise()
+        result = Await promise4.ResolveAsync()
+
+        Console.WriteLine("Result state:" & result?.State.ToString())
+        Console.WriteLine("Result type:" & (If(result?.Data?.GetType().ToString(), "null")))
+    End Function
 
 #End Region
 End Class


### PR DESCRIPTION
This PR adds an example of the JavaScript promise wrapper implementation and connecting JavaScript promises with async/await on the .NET side.