### PR TITLE
Remove IFrame.LoadHtml() and IFrame.LoadData() usages from examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Set the default behavior, in case core.autocrlf is not set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c 	text diff=cpp
+*.cc 	text diff=cpp
+*.cxx 	text diff=cpp
+*.cpp 	text diff=cpp
+*.c++ 	text diff=cpp
+*.hpp 	text diff=cpp
+*.h 	text diff=cpp
+*.h++ 	text diff=cpp
+*.hh 	text diff=cpp
+
+*.cs    text diff=csharp
+
+*.csproj text merge=union eol=crlf
+*.sln    text merge=union eol=crlf
+
+*.vbproj text eol=crlf
+
+*.vcxproj text eol=crlf
+*.vcxitems text eol=crlf
+*.props text eol=crlf
+*.filters text eol=crlf
+
+*.patch eol=lf

--- a/csharp/ContextMenu.WinForms/Form1.cs
+++ b/csharp/ContextMenu.WinForms/Form1.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using DotNetBrowser.Browser;
@@ -68,9 +69,7 @@ namespace ContextMenu.WinForms
                      browser.ShowContextMenuHandler =
                          new AsyncHandler<ShowContextMenuParameters, ShowContextMenuResponse>(ShowMenu);
 
-                     browser
-                        .MainFrame
-                        .LoadHtml(@"<html>
+                     byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                     <head>
                                       <meta charset='UTF-8'>
                                     </head>
@@ -78,6 +77,7 @@ namespace ContextMenu.WinForms
                                     <textarea autofocus cols='30' rows='20'>Simpple mistakee</textarea>
                                     </body>
                                     </html>");
+                     browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes));
                  }, TaskScheduler.FromCurrentSynchronizationContext());
 
             InitializeComponent();

--- a/csharp/Dom.DragAndDrop.WinForms/Form1.cs
+++ b/csharp/Dom.DragAndDrop.WinForms/Form1.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using DotNetBrowser.Browser;
@@ -63,7 +64,7 @@ namespace Dom.DragAndDrop.WinForms
                      browserView1.InitializeFrom(browser);
                      browser.InjectJsHandler = new Handler<InjectJsParameters>(OnInjectJs);
                      browser.ConsoleMessageReceived += (sender, args) => { Debug.WriteLine(args.LineNumber+" > "+args.Message); };
-                     browser.MainFrame.LoadHtml(@"<html>
+                     byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                     <head>
                                       <meta charset='UTF-8'>
                                       <style type='text/css'>
@@ -85,7 +86,8 @@ namespace Dom.DragAndDrop.WinForms
                                         Drop a file here.
                                     </div >
                                     </body>
-                                    </html>")
+                                    </html>");
+                     browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
                             .ContinueWith(OnHtmlLoaded);
                  }, TaskScheduler.FromCurrentSynchronizationContext());
 

--- a/csharp/DomCreateElement/Program.cs
+++ b/csharp/DomCreateElement/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
 using DotNetBrowser.Engine;
@@ -46,7 +47,9 @@ namespace DomCreateElement
                     {
                         Console.WriteLine("Browser created");
 
-                        browser.MainFrame.LoadHtml("<html><body><div id='root'></div></body></html>").Wait();
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes("<html><body><div id='root'></div></body></html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
+                        
                         Console.WriteLine("Initial HTML: " + browser.MainFrame.Html);
                         IDocument document = browser.MainFrame.Document;
 

--- a/csharp/DomCreateEvent/Program.cs
+++ b/csharp/DomCreateEvent/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using System.Threading;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
@@ -48,14 +49,14 @@ namespace DomCreateEvent
                     {
                         Console.WriteLine("Browser created");
 
-                        browser.MainFrame.LoadHtml("<html><body><div id='root'></div></body></html>")
-                               .Wait();
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes("<html><body><div id='root'></div></body></html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
+
                         IDocument document = browser.MainFrame.Document;
+                        INode root = document.GetElementById("root");
 
                         EventType eventType = new EventType("MyEvent");
                         var myEvent = document.CreateEvent(eventType, new EventParameters.Builder().Build());
-
-                        INode root = document.GetElementById("root");
 
                         EventHandler<DomEventArgs> domEventHandler = (s, e) =>
                         {

--- a/csharp/DomForm/Program.cs
+++ b/csharp/DomForm/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using System.Threading;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
@@ -47,16 +48,17 @@ namespace DomForm
                     {
                         Console.WriteLine("Browser created");
 
-                        browser.MainFrame.LoadHtml("<html><body><form name=\"myForm\">"
-                                                   + "First name: <input type=\"text\" id=\"firstName\" name=\"firstName\"/><br/>"
-                                                   + "Last name: <input type=\"text\" id=\"lastName\" name=\"lastName\"/><br/>"
-                                                   + "<input type='checkbox' id='agreement' name='agreement' value='agreed'>I agree<br>"
-                                                   + "<input type='button' id='saveButton' value=\"Save\" onclick=\""
-                                                   + "if(document.getElementById('agreement').checked){"
-                                                   + "    console.log(document.getElementById('firstName').value +' '+"
-                                                   + "document.getElementById('lastName').value);}"
-                                                   + "\"/>"
-                                                   + "</form></body></html>").Wait();
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes("<html><body><form name=\"myForm\">"
+                                                                  + "First name: <input type=\"text\" id=\"firstName\" name=\"firstName\"/><br/>"
+                                                                  + "Last name: <input type=\"text\" id=\"lastName\" name=\"lastName\"/><br/>"
+                                                                  + "<input type='checkbox' id='agreement' name='agreement' value='agreed'>I agree<br>"
+                                                                  + "<input type='button' id='saveButton' value=\"Save\" onclick=\""
+                                                                  + "if(document.getElementById('agreement').checked){"
+                                                                  + "    console.log(document.getElementById('firstName').value +' '+"
+                                                                  + "document.getElementById('lastName').value);}"
+                                                                  + "\"/>"
+                                                                  + "</form></body></html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
 
                         IDocument document = browser.MainFrame.Document;
                         IInputElement firstName = (IInputElement) document.GetElementByName("firstName");

--- a/csharp/DomGetAttributes/Program.cs
+++ b/csharp/DomGetAttributes/Program.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
 using DotNetBrowser.Engine;
@@ -47,9 +48,8 @@ namespace DomGetAttributes
                     {
                         Console.WriteLine("Browser created");
 
-                        browser.MainFrame
-                               .LoadHtml("<html><body><a href='#' id='link' title='link title'></a></body></html>")
-                               .Wait();
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes("<html><body><a href='#' id='link' title='link title'></a></body></html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
 
                         IDocument document = browser.MainFrame.Document;
                         IElement link = document.GetElementById("link");

--- a/csharp/DomQuerySelector/Program.cs
+++ b/csharp/DomQuerySelector/Program.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Dom;
 using DotNetBrowser.Engine;
@@ -47,11 +48,12 @@ namespace DomQuerySelector
                     {
                         Console.WriteLine("Browser created");
 
-                        browser.MainFrame.LoadHtml("<html><body><div id='root'>"
-                                                   + "<p>paragraph1</p>"
-                                                   + "<p>paragraph2</p>"
-                                                   + "<p>paragraph3</p>"
-                                                   + "</div></body></html>")
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes("<html><body><div id='root'>"
+                                                                  + "<p>paragraph1</p>"
+                                                                  + "<p>paragraph2</p>"
+                                                                  + "<p>paragraph3</p>"
+                                                                 + "</div></body></html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
                                .Wait();
                         IDocument document = browser.MainFrame.Document;
                         IElement documentElement = document.DocumentElement;

--- a/csharp/FindText/Program.cs
+++ b/csharp/FindText/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using System.Threading;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
@@ -50,7 +51,8 @@ namespace FindText
                     {
                         Console.WriteLine("Browser created");
                         browser.Size = new Size(700, 500);
-                        browser.MainFrame.LoadHtml("<html><body><p>Find me</p><p>Find me</p></body></html>").Wait();
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes("<html><body><p>Find me</p><p>Find me</p></body></html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
 
                         Thread.Sleep(2000);
                         // Find text from the beginning of the loaded web page.

--- a/csharp/InjectObjectForScripting/Program.cs
+++ b/csharp/InjectObjectForScripting/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Browser.Handlers;
 using DotNetBrowser.Engine;
@@ -57,7 +58,8 @@ namespace InjectObjectForScripting
                         Console.WriteLine("Browser created");
                         browser.Size = new Size(700, 500);
                         browser.InjectJsHandler = new Handler<InjectJsParameters>(InjectObjectForScripting);
-                        browser.MainFrame.LoadHtml(@"<html>
+
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                      <body>
                                         <script type='text/javascript'>
                                             var SetTitle = function () 
@@ -66,8 +68,8 @@ namespace InjectObjectForScripting
                                             };
                                         </script>
                                      </body>
-                                   </html>")
-                               .Wait();
+                                   </html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
 
                         browser.MainFrame.ExecuteJavaScript<IJsObject>("window.SetTitle();").Wait();
 

--- a/csharp/JavaScriptBridge.Promises/Program.cs
+++ b/csharp/JavaScriptBridge.Promises/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
@@ -49,7 +50,7 @@ namespace JavaScriptBridge.Promises
                     {
                         Console.WriteLine("Browser created");
                         browser.Size = new Size(700, 500);
-                        browser.MainFrame.LoadHtml(@"<html>
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                      <body>
                                         <script type='text/javascript'>
                                             function CreatePromise(success) 
@@ -65,8 +66,9 @@ namespace JavaScriptBridge.Promises
                                             };
                                         </script>
                                      </body>
-                                   </html>")
-                               .Wait();
+                                   </html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait();
+
                         IJsObject window = browser.MainFrame.ExecuteJavaScript<IJsObject>("window").Result;
                         //Prepare promise handlers
                         Action<object> promiseResolvedHandler = o => Console.WriteLine("Success: " + o);

--- a/csharp/JavaScriptBridge.WinForms/Form1.cs
+++ b/csharp/JavaScriptBridge.WinForms/Form1.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using System.Windows.Forms;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
@@ -55,9 +56,7 @@ namespace JavaScriptBridge.WinForms
             browser = engine.CreateBrowser();
             webView.InitializeFrom(browser);
             browser.ConsoleMessageReceived += (sender, args) => { };
-            browser
-               .MainFrame
-               .LoadHtml(@"<html>
+            byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                         <head>
                           <meta charset='UTF-8'>
                           <style>body{padding: 0; margin: 0; width:100%; height: 100%;}
@@ -66,12 +65,13 @@ namespace JavaScriptBridge.WinForms
                         </head>
                         <body>
                         <div>
-                        <textarea id='text' class='fill' autofocus cols='30' rows='20'>Sample text</textarea>
                         <button id='updateForm' type='button' onClick='updateForm(document.getElementById(""text"").value)'>&lt; Update Form</button> 
+                        <textarea id='text' class='fill' autofocus cols='30' rows='20'>Sample text</textarea>
                         </div>
                         </body>
-                        </html>")
-               .Wait();
+                        </html>");
+            browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
+                   .Wait();
             IJsObject window = browser.MainFrame.ExecuteJavaScript<IJsObject>("window").Result;
             window.Properties["updateForm"] = (Action<string>) UpdateForm;
             FormClosing += Form1_FormClosing;

--- a/csharp/JavaScriptBridge/Program.cs
+++ b/csharp/JavaScriptBridge/Program.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
 using DotNetBrowser.Geometry;
@@ -54,7 +55,7 @@ namespace JavaScriptBridge
                     {
                         Console.WriteLine("Browser created");
                         browser.Size = new Size(700, 500);
-                        browser.MainFrame.LoadHtml(@"<html>
+                        byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                      <body>
                                         <script type='text/javascript'>
                                             var ShowData = function (a) 
@@ -66,7 +67,8 @@ namespace JavaScriptBridge
                                             };
                                         </script>
                                      </body>
-                                   </html>")
+                                   </html>");
+                        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
                                .Wait();
 
                         Person person = new Person("Jack", 30, true)

--- a/csharp/KeyboardEventSimulation.WinForms/Form1.cs
+++ b/csharp/KeyboardEventSimulation.WinForms/Form1.cs
@@ -20,6 +20,8 @@
 
 #endregion
 
+using System;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using DotNetBrowser.Browser;
@@ -62,12 +64,12 @@ namespace KeyboardEventSimulation.WinForms
                      // Embed BrowserView component into main layout.
                      Controls.Add(browserView);
                      browserView.InitializeFrom(browser);
-                     browser.MainFrame
-                            .LoadHtml(@"<html>
+                     byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                           <body>
                                             <input type='text' autofocus></input>
                                           </body>
-                                        </html>")
+                                        </html>");
+                     browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
                             .ContinueWith(SimulateInput);
                  }, TaskScheduler.FromCurrentSynchronizationContext());
         }

--- a/csharp/KeyboardEventSimulation.Wpf/MainWindow.xaml.cs
+++ b/csharp/KeyboardEventSimulation.Wpf/MainWindow.xaml.cs
@@ -23,6 +23,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using DotNetBrowser.Browser;
@@ -64,12 +65,12 @@ namespace KeyboardEventSimulation.Wpf
                          // Embed BrowserView component into main layout.
                          MainLayout.Children.Add(browserView);
                          browserView.InitializeFrom(browser);
-                         browser.MainFrame
-                                .LoadHtml(@"<html>
+                         byte[] htmlBytes = Encoding.UTF8.GetBytes(@"<html>
                                             <body>
                                                 <input type='text' autofocus></input>
                                             </body>
-                                           </html>")
+                                           </html>");
+                         browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
                                 .ContinueWith(SimulateInput);
                      }, TaskScheduler.FromCurrentSynchronizationContext());
 

--- a/csharp/SeleniumChromeDriver/Form1.cs
+++ b/csharp/SeleniumChromeDriver/Form1.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.Text;
 using System.Windows.Forms;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
@@ -28,6 +29,9 @@ using DotNetBrowser.WinForms;
 
 namespace SeleniumChromeDriver
 {
+    /// <summary>
+    ///     This example demonstrates how to use Selenium with DotNetBrowser.
+    /// </summary>
     public partial class Form1 : Form
     {
         private const int RemoteDebuggingPort = 9222;
@@ -75,7 +79,8 @@ namespace SeleniumChromeDriver
             engine = EngineFactory.Create(engineOptions);
             browser = engine.CreateBrowser();
 
-            browser.MainFrame.LoadHtml("<h1>Waiting for Selenium...</h1>");
+            byte[] htmlBytes = Encoding.UTF8.GetBytes("<h1>Waiting for Selenium...</h1>");
+            browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes));
 
             browserView = new BrowserView() { Dock = DockStyle.Fill };
             browserView.InitializeFrom(browser);

--- a/csharp/SeleniumChromeDriver/SeleniumChromeDriver.csproj
+++ b/csharp/SeleniumChromeDriver/SeleniumChromeDriver.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -110,11 +110,11 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets'))" />
   </Target>
 </Project>

--- a/csharp/SeleniumChromeDriver/packages.config
+++ b/csharp/SeleniumChromeDriver/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetBrowser" version="2.6.0" targetFramework="net472" />
   <package id="DotNetBrowser.Chromium.Win-x64" version="2.6.0" targetFramework="net472" />
@@ -6,5 +6,5 @@
   <package id="DotNetBrowser.WinForms" version="2.6.0" targetFramework="net472" />
   <package id="protobuf-net" version="2.4.0" targetFramework="net472" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net472" />
-  <package id="Selenium.WebDriver.ChromeDriver" version="88.0.4324.2700" targetFramework="net45" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="90.0.4430.2400" targetFramework="net45" />
 </packages>

--- a/csharp/TransparentWebPage.Wpf/MainWindow.xaml.cs
+++ b/csharp/TransparentWebPage.Wpf/MainWindow.xaml.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using DotNetBrowser.Browser;
@@ -56,23 +57,21 @@ namespace TransparentWebPage.Wpf
                     .ContinueWith(t =>
                      {
                          WebBrowser1.InitializeFrom(browser);
-                         browser
-                            .MainFrame
-                                .LoadHtml(
-                                        "<html>\n"
-                                        + "     <body>"
-                                        + "         <div style='background: yellow; opacity: 0.7;'>\n"
-                                        + "             This text is in the yellow half-transparent div."
-                                        + "        </div>\n"
-                                        + "         <div style='background: red;'>\n"
-                                        + "             This text is in the red opaque div and should appear as is."
-                                        + "        </div>\n"
-                                        + "         <div>\n"
-                                        + "             This text is in the non-styled div and should appear as a text"
-                                        + " on the completely transparent background."
-                                        + "        </div>\n"
-                                        + "    </body>\n"
-                                        + " </html>");
+                         byte[] htmlBytes = Encoding.UTF8.GetBytes("<html>\n"
+                                                                   + "     <body>"
+                                                                   + "         <div style='background: yellow; opacity: 0.7;'>\n"
+                                                                   + "             This text is in the yellow half-transparent div."
+                                                                   + "        </div>\n"
+                                                                   + "         <div style='background: red;'>\n"
+                                                                   + "             This text is in the red opaque div and should appear as is."
+                                                                   + "        </div>\n"
+                                                                   + "         <div>\n"
+                                                                   + "             This text is in the non-styled div and should appear as a text"
+                                                                   + " on the completely transparent background."
+                                                                   + "        </div>\n"
+                                                                   + "    </body>\n"
+                                                                   + " </html>");
+                         browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes));
                      }, TaskScheduler.FromCurrentSynchronizationContext());
 
                 InitializeComponent();

--- a/csharp/WebStorage/Program.cs
+++ b/csharp/WebStorage/Program.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.IO;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
 using DotNetBrowser.Frames;
@@ -48,17 +49,7 @@ namespace WebStorage
                     {
                         Console.WriteLine("Browser created");
 
-                        browser.MainFrame
-                               .LoadHtml(new LoadHtmlParameters("<html><body>"
-                                                                + "<script>localStorage.myKey = \"Initial Value\";"
-                                                                + "function myFunction(){return localStorage.myKey;}"
-                                                                + "</script></body></html>"
-                                                                )
-                                {
-                                    BaseUrl = "https://teamdev.com",
-                                    Replace = true
-                                })
-                               .Wait();
+                        browser.Navigation.LoadUrl(Path.GetFullPath("html.html")).Wait();
                         IWebStorage webStorage = browser.MainFrame.LocalStorage;
                         // Read and display the 'myKey' storage value.
                         Console.Out.WriteLine("The initial myKey value: " + webStorage["myKey"]);

--- a/csharp/WebStorage/WebStorage.csproj
+++ b/csharp/WebStorage/WebStorage.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -76,6 +76,11 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="html.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/csharp/WebStorage/html.html
+++ b/csharp/WebStorage/html.html
@@ -1,0 +1,8 @@
+﻿<html>
+<body>
+<script>
+  localStorage.myKey = "Initial Value";
+  function myFunction() { return localStorage.myKey; }
+</script>
+</body>
+</html>

--- a/vbnet/ContextMenu.WinForms/Form1.vb
+++ b/vbnet/ContextMenu.WinForms/Form1.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports System.Threading.Tasks
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Browser.Handlers
@@ -57,15 +58,15 @@ Namespace ContextMenu.WinForms
                 browser.ShowContextMenuHandler =
                                      New AsyncHandler(Of ShowContextMenuParameters, ShowContextMenuResponse)(
                                          AddressOf ShowMenu)
-                browser.MainFrame.LoadHtml(
-                    "<html>
-                    <head>
-                      <meta charset='UTF-8'>
-                    </head>
-                    <body>
-                    <textarea autofocus cols='30' rows='20'>Simpple mistakee</textarea>
-                    </body>
-                    </html>")
+                Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
+                                    <head>
+                                      <meta charset='UTF-8'>
+                                    </head>
+                                    <body>
+                                    <textarea autofocus cols='30' rows='20'>Simpple mistakee</textarea>
+                                    </body>
+                                    </html>")
+                browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
             End Sub, TaskScheduler.FromCurrentSynchronizationContext())
             InitializeComponent()
             AddHandler Me.FormClosing, AddressOf Form1_FormClosing
@@ -109,7 +110,9 @@ Namespace ContextMenu.WinForms
                     Dim addToDictionary As String = If(spellCheckMenu.AddToDictionaryMenuItemText, "Add to Dictionary")
 
                     popupMenu.MenuItems.Add(BuildMenuItem(addToDictionary, True, Sub()
-                        engine.SpellChecker?.CustomDictionary?.Add(spellCheckMenu.MisspelledWord)
+                        If Not String.IsNullOrEmpty(spellCheckMenu.MisspelledWord) Then
+                            engine.SpellChecker?.CustomDictionary?.Add(spellCheckMenu.MisspelledWord)
+                        End If
                         tcs.TrySetResult(ShowContextMenuResponse.Close())
                     End Sub))
 

--- a/vbnet/Dom.DragAndDrop.WinForms/Form1.vb
+++ b/vbnet/Dom.DragAndDrop.WinForms/Form1.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Browser.Handlers
 Imports DotNetBrowser.Dom
@@ -52,29 +53,31 @@ Namespace Dom.DragAndDrop.WinForms
 					 AddHandler browser.ConsoleMessageReceived, Sub(sender, args)
 						 Debug.WriteLine(args.LineNumber & " > " & args.Message)
 					 End Sub
-					 browser.MainFrame.LoadHtml("<html>
-                                    <head>
-                                      <meta charset='UTF-8'>
-                                      <style type='text/css'>
-                                        #dropZone {
-                                            text-align: center;    
-    
-                                            width: 400px;
-                                            padding: 50px 0;
-                                            margin: 50px auto;
-                                            
-                                            background: #eee;
-                                            border: 1px solid #ccc;
-                                        }
-                                      </style>
-                                    </head>
-                                    <body>
-                                    
-                                    <div id='dropZone'>
-                                        Drop a file here.
-                                    </div >
-                                    </body>
-                                    </html>").ContinueWith(AddressOf OnHtmlLoaded)
+			         Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
+                                        <head>
+                                          <meta charset='UTF-8'>
+                                          <style type='text/css'>
+                                            #dropZone {
+                                                text-align: center;    
+        
+                                                width: 400px;
+                                                padding: 50px 0;
+                                                margin: 50px auto;
+                                                
+                                                background: #eee;
+                                                border: 1px solid #ccc;
+                                            }
+                                          </style>
+                                        </head>
+                                        <body>
+                                        
+                                        <div id='dropZone'>
+                                            Drop a file here.
+                                        </div >
+                                        </body>
+                                        </html>")
+			         browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)) _
+                                     .ContinueWith(AddressOf OnHtmlLoaded)
 			End Sub, TaskScheduler.FromCurrentSynchronizationContext())
 
 			InitializeComponent()

--- a/vbnet/DomCreateElement/Program.vb
+++ b/vbnet/DomCreateElement/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Dom
 Imports DotNetBrowser.Engine
@@ -39,7 +40,8 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
 
-                    browser.MainFrame.LoadHtml("<html><body><div id='root'></div></body></html>").Wait()
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html><body><div id='root'></div></body></html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
                     Console.WriteLine("Initial HTML: " & browser.MainFrame.Html)
                     Dim document As IDocument = browser.MainFrame.Document
 

--- a/vbnet/DomCreateEvent/Program.vb
+++ b/vbnet/DomCreateEvent/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports System.Threading
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Dom
@@ -41,7 +42,8 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
 
-                    browser.MainFrame.LoadHtml("<html><body><div id='root'></div></body></html>").Wait()
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html><body><div id='root'></div></body></html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
                     Dim document As IDocument = browser.MainFrame.Document
 
                     Dim eventType As New EventType("MyEvent")

--- a/vbnet/DomForm/Program.vb
+++ b/vbnet/DomForm/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports System.Threading
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Dom
@@ -40,16 +41,17 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
 
-                    browser.MainFrame.LoadHtml("<html><body><form name=""myForm"">" &
-                                                "First name: <input type=""text"" id=""firstName"" name=""firstName""/><br/>" &
-                                                "Last name: <input type=""text"" id=""lastName"" name=""lastName""/><br/>" &
-                                                "<input type='checkbox' id='agreement' name='agreement' value='agreed'>I agree<br>" &
-                                                "<input type='button' id='saveButton' value=""Save"" onclick=""" &
-                                                "if(document.getElementById('agreement').checked){" &
-                                                "    console.log(document.getElementById('firstName').value +' '+" &
-                                                "document.getElementById('lastName').value);}" &
-                                                """/>" &
-                                                "</form></body></html>").Wait()
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html><body><form name=""myForm"">" &
+                                                                     "First name: <input type=""text"" id=""firstName"" name=""firstName""/><br/>" &
+                                                                     "Last name: <input type=""text"" id=""lastName"" name=""lastName""/><br/>" &
+                                                                     "<input type='checkbox' id='agreement' name='agreement' value='agreed'>I agree<br>" &
+                                                                     "<input type='button' id='saveButton' value=""Save"" onclick=""" &
+                                                                     "if(document.getElementById('agreement').checked){" &
+                                                                     "    console.log(document.getElementById('firstName').value +' '+" &
+                                                                     "document.getElementById('lastName').value);}" &
+                                                                     """/>" &
+                                                                     "</form></body></html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
 
                     Dim document As IDocument = browser.MainFrame.Document
                     Dim firstName = DirectCast(document.GetElementByName("firstName"), IInputElement)

--- a/vbnet/DomGetAttributes/Program.vb
+++ b/vbnet/DomGetAttributes/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Dom
 Imports DotNetBrowser.Engine
@@ -39,8 +40,9 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
 
-                    browser.MainFrame.LoadHtml(
-                        "<html><body><a href='#' id='link' title='link title'></a></body></html>").Wait()
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes(
+                        "<html><body><a href='#' id='link' title='link title'></a></body></html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
                     Dim document As IDocument = browser.MainFrame.Document
                     Dim link As IElement = document.GetElementById("link")
                     Dim attributes As IDictionary(Of String, String) = link.Attributes

--- a/vbnet/DomQuerySelector/Program.vb
+++ b/vbnet/DomQuerySelector/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Dom
 Imports DotNetBrowser.Engine
@@ -39,11 +40,12 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
 
-                    browser.MainFrame.LoadHtml("<html><body><div id='root'>" &
-                                               "<p>paragraph1</p>" &
-                                               "<p>paragraph2</p>" &
-                                               "<p>paragraph3</p>" &
-                                               "</div></body></html>").Wait()
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html><body><div id='root'>" &
+                                                                     "<p>paragraph1</p>" &
+                                                                     "<p>paragraph2</p>" &
+                                                                     "<p>paragraph3</p>" &
+                                                                     "</div></body></html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
                     Dim document As IDocument = browser.MainFrame.Document
                     Dim documentElement As IElement = document.DocumentElement
                     ' Get the div with id = "root".

--- a/vbnet/FindText/Program.vb
+++ b/vbnet/FindText/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports System.Threading
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
@@ -43,7 +44,8 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
                     browser.Size = New Size(700, 500)
-                    browser.MainFrame.LoadHtml("<html><body><p>Find me</p><p>Find me</p></body></html>").Wait()
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html><body><p>Find me</p><p>Find me</p></body></html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
 
                     Thread.Sleep(2000)
                     ' Find text from the beginning of the loaded web page.

--- a/vbnet/InjectObjectForScripting/Program.vb
+++ b/vbnet/InjectObjectForScripting/Program.vb
@@ -21,6 +21,7 @@
 #End Region
 
 Imports System
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Browser.Handlers
 Imports DotNetBrowser.Engine
@@ -50,7 +51,7 @@ Namespace InjectObjectForScripting
 						Console.WriteLine("Browser created")
 						browser.Size = New Size(700, 500)
 						browser.InjectJsHandler = New Handler(Of InjectJsParameters)(AddressOf InjectObjectForScripting)
-						browser.MainFrame.LoadHtml("<html>
+					    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                                      <body>
                                         <script type='text/javascript'>
                                             var SetTitle = function () 
@@ -59,7 +60,8 @@ Namespace InjectObjectForScripting
                                             };
                                         </script>
                                      </body>
-                                   </html>").Wait()
+                                   </html>")
+					    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
 
 						browser.MainFrame.ExecuteJavaScript(Of IJsObject)("window.SetTitle();").Wait()
 

--- a/vbnet/JavaScriptBridge.Promises/Program.vb
+++ b/vbnet/JavaScriptBridge.Promises/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.Geometry
@@ -41,7 +42,7 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
                     browser.Size = New Size(700, 500)
-                    browser.MainFrame.LoadHtml("<html>
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                                      <body>
                                         <script type='text/javascript'>
                                             function CreatePromise(success) 
@@ -57,7 +58,8 @@ Friend Class Program
                                             };
                                         </script>
                                      </body>
-                                   </html>").Wait()
+                                   </html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
                     Dim window As IJsObject = browser.MainFrame.ExecuteJavaScript(Of IJsObject)("window").Result
                     'Prepare promise handlers
                     Dim promiseResolvedHandler As Action(Of Object) = Sub(o) Console.WriteLine("Success: " & o.ToString())

--- a/vbnet/JavaScriptBridge.WinForms/Form1.vb
+++ b/vbnet/JavaScriptBridge.WinForms/Form1.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.Js
@@ -47,7 +48,7 @@ Namespace JavaScriptBridge.WinForms
 			webView.InitializeFrom(browser)
 			AddHandler browser.ConsoleMessageReceived, Sub(sender, args)
 			End Sub
-			browser.MainFrame.LoadHtml("<html>
+		    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                         <head>
                           <meta charset='UTF-8'>
                           <style>body{padding: 0; margin: 0; width:100%; height: 100%;}
@@ -60,7 +61,8 @@ Namespace JavaScriptBridge.WinForms
                         <button id='updateForm' type='button' onClick='updateForm(document.getElementById(""text"").value)'>&lt; Update Form</button> 
                         </div>
                         </body>
-                        </html>").Wait()
+                        </html>")
+		    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
 			Dim window As IJsObject = browser.MainFrame.ExecuteJavaScript(Of IJsObject)("window").Result
 			window.Properties("updateForm") = CType(AddressOf UpdateForm, Action(Of String))
 			AddHandler Me.FormClosing, AddressOf Form1_FormClosing

--- a/vbnet/JavaScriptBridge.WinForms/Form1.vb
+++ b/vbnet/JavaScriptBridge.WinForms/Form1.vb
@@ -48,7 +48,7 @@ Namespace JavaScriptBridge.WinForms
 			webView.InitializeFrom(browser)
 			AddHandler browser.ConsoleMessageReceived, Sub(sender, args)
 			End Sub
-		    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
+			Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                         <head>
                           <meta charset='UTF-8'>
                           <style>body{padding: 0; margin: 0; width:100%; height: 100%;}
@@ -62,7 +62,7 @@ Namespace JavaScriptBridge.WinForms
                         </div>
                         </body>
                         </html>")
-		    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
+			browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)).Wait()
 			Dim window As IJsObject = browser.MainFrame.ExecuteJavaScript(Of IJsObject)("window").Result
 			window.Properties("updateForm") = CType(AddressOf UpdateForm, Action(Of String))
 			AddHandler Me.FormClosing, AddressOf Form1_FormClosing

--- a/vbnet/JavaScriptBridge/Program.vb
+++ b/vbnet/JavaScriptBridge/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.Geometry
@@ -45,8 +46,7 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
                     browser.Size = New Size(700, 500)
-                    browser.MainFrame.LoadHtml(
-                                   "<html>
+                    Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                                      <body>
                                         <script type='text/javascript'>
                                             var ShowData = function (a) 
@@ -58,8 +58,9 @@ Friend Class Program
                                             };
                                         </script>
                                      </body>
-                                   </html>") _
-                        .Wait()
+                                   </html>")
+                    browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)) _
+                    .Wait()
                     Dim person = New Person("Jack", 30, True)
                     person.Children = New Dictionary(Of Double, Person)()
                     person.Children.Add(1.0, New Person("Oliver", 10, True))

--- a/vbnet/KeyboardEventSimulation.WinForms/Form1.vb
+++ b/vbnet/KeyboardEventSimulation.WinForms/Form1.vb
@@ -21,6 +21,7 @@
 
 #End Region
 Imports System.ComponentModel
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.Input.Keyboard
@@ -56,11 +57,12 @@ Public Class Form1
                 browserView.InitializeFrom(browser)
                 browserView.Dock = DockStyle.Fill
 
-                browser.MainFrame.LoadHtml("<html>
+                Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                                                 <body>
                                                     <input type='text' autofocus></input>
                                                 </body>
-                                            </html>") _
+                                            </html>")
+                browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)) _
                                      .ContinueWith(AddressOf SimulateInput)
             End Sub, TaskScheduler.FromCurrentSynchronizationContext())
             

--- a/vbnet/KeyboardEventSimulation.Wpf/MainWindow.xaml.vb
+++ b/vbnet/KeyboardEventSimulation.Wpf/MainWindow.xaml.vb
@@ -21,6 +21,7 @@
 #End Region
 
 Imports System.ComponentModel
+Imports System.Text
 Imports System.Threading.Tasks
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
@@ -55,11 +56,12 @@ Partial Public Class MainWindow
 
                 browserView.InitializeFrom(browser)
 
-                browser.MainFrame.LoadHtml("<html>
+                Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<html>
                                                 <body>
                                                     <input type='text' autofocus></input>
                                                 </body>
-                                            </html>") _
+                                            </html>")
+                browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes)) _
                                      .ContinueWith(AddressOf SimulateInput)
             End Sub, TaskScheduler.FromCurrentSynchronizationContext())
 

--- a/vbnet/SeleniumChromeDriver/Form1.vb
+++ b/vbnet/SeleniumChromeDriver/Form1.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.WinForms
@@ -70,7 +71,8 @@ Public Class Form1
         engine = EngineFactory.Create(engineOptions)
         browser = engine.CreateBrowser()
 
-        browser.MainFrame.LoadHtml("<h1>Waiting for Selenium...</h1>")
+        Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<h1>Waiting for Selenium...</h1>")
+        browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
 
         browserView = new BrowserView()
         browserView.Dock = DockStyle.Fill

--- a/vbnet/SeleniumChromeDriver/SeleniumChromeDriver.vbproj
+++ b/vbnet/SeleniumChromeDriver/SeleniumChromeDriver.vbproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -169,11 +169,11 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
-  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets')" />
+  <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.88.0.4324.2700\build\Selenium.WebDriver.ChromeDriver.targets'))" />
+    <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets'))" />
   </Target>
 </Project>

--- a/vbnet/SeleniumChromeDriver/packages.config
+++ b/vbnet/SeleniumChromeDriver/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DotNetBrowser" version="2.6.0" targetFramework="net45" />
   <package id="DotNetBrowser.Chromium.Win-x64" version="2.6.0" targetFramework="net45" />
@@ -6,5 +6,5 @@
   <package id="DotNetBrowser.WinForms" version="2.6.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver.ChromeDriver" version="88.0.4324.2700" targetFramework="net45" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="90.0.4430.2400" targetFramework="net45" />
 </packages>

--- a/vbnet/TransparentWebPage.Wpf/MainWindow.xaml.vb
+++ b/vbnet/TransparentWebPage.Wpf/MainWindow.xaml.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports System.Threading.Tasks
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
@@ -46,21 +47,23 @@ Partial Public Class MainWindow
                 browser.Settings.TransparentBackgroundEnabled = True
             End Sub).ContinueWith(Sub(t)
                 WebBrowser1.InitializeFrom(browser)
-                browser.MainFrame.LoadHtml(
-                    "<html>" & vbLf & 
-                    "     <body>" & 
-                    "         <div style='background: yellow; opacity: 0.7;'>" & vbLf &
-                    "             This text is in the yellow half-transparent div." &
-                    "        </div>" & vbLf &
-                    "         <div style='background: red;'>" & vbLf &
-                    "             This text is in the red opaque div and should appear as is." &
-                    "        </div>" & vbLf &
-                    "         <div>" & vbLf &
-                    "             This text is in the non-styled div and should appear as a text" &
-                    " on the completely transparent background." &
-                    "        </div>" & vbLf & 
-                    "    </body>" & vbLf &
-                    " </html>")
+                Dim htmlBytes() As Byte =
+                        Encoding.UTF8.GetBytes(
+                            "<html>" & vbLf &
+                            "     <body>" &
+                            "         <div style='background: yellow; opacity: 0.7;'>" & vbLf &
+                            "             This text is in the yellow half-transparent div." &
+                            "        </div>" & vbLf &
+                            "         <div style='background: red;'>" & vbLf &
+                            "             This text is in the red opaque div and should appear as is." &
+                            "        </div>" & vbLf &
+                            "         <div>" & vbLf &
+                            "             This text is in the non-styled div and should appear as a text" &
+                            " on the completely transparent background." &
+                            "        </div>" & vbLf &
+                            "    </body>" & vbLf &
+                            " </html>")
+                browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))
             End Sub, TaskScheduler.FromCurrentSynchronizationContext())
 
             InitializeComponent()

--- a/vbnet/WebStorage/Program.vb
+++ b/vbnet/WebStorage/Program.vb
@@ -20,6 +20,7 @@
 
 #End Region
 
+Imports System.Text
 Imports DotNetBrowser.Browser
 Imports DotNetBrowser.Engine
 Imports DotNetBrowser.Frames
@@ -41,15 +42,7 @@ Friend Class Program
                 Using browser As IBrowser = engine.CreateBrowser()
                     Console.WriteLine("Browser created")
 
-                    browser.MainFrame.LoadHtml(
-                        New LoadHtmlParameters(
-                            "<html><body>" &
-                            "<script>localStorage.myKey = ""Initial Value"";" &
-                            "function myFunction(){return localStorage.myKey;}" &
-                            "</script></body></html>") With {
-                                                  .BaseUrl = "https://teamdev.com",
-                                                  .Replace = True
-                                                  }).Wait()
+                    browser.Navigation.LoadUrl(System.IO.Path.GetFullPath("html.html")).Wait()
 
                     Dim webStorage As IWebStorage = browser.MainFrame.LocalStorage
                     ' Read and display the 'myKey' storage value.

--- a/vbnet/WebStorage/WebStorage.vbproj
+++ b/vbnet/WebStorage/WebStorage.vbproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -99,6 +99,11 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="html.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/vbnet/WebStorage/html.html
+++ b/vbnet/WebStorage/html.html
@@ -1,0 +1,8 @@
+﻿<html>
+<body>
+<script>
+  localStorage.myKey = "Initial Value";
+  function myFunction() { return localStorage.myKey; }
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR removes `IFrame.LoadHtml()` and `IFrame.LoadData()` methods and replaces them with `INavigation.LoadUrl()` method. See [known limitation case](https://dotnetbrowser-support.teamdev.com/docs/guides/migration/v2-4-v2-5.html#known-limitations).