### PR TITLE
Improve ContextMenu.WinForms examples

### DIFF
--- a/vbnet/ContextMenu.WinForms/Form1.vb
+++ b/vbnet/ContextMenu.WinForms/Form1.vb
@@ -140,8 +140,8 @@ Namespace ContextMenu.WinForms
                     AddHandler popupMenu.Closed, menuOnClosed
 
                     ' Show the context menu.
-                    Dim location_Conflict As New Point(parameters.Location.X, parameters.Location.Y)
-                    popupMenu.Show(Me, location_Conflict)
+                    Dim menuLocation As New Point(parameters.Location.X, parameters.Location.Y)
+                    popupMenu.Show(Me, menuLocation)
                     tcs.TrySetResult(ShowContextMenuResponse.Close())
                 End Sub))
             Else

--- a/vbnet/ContextMenu.WinForms/My Project/AssemblyInfo.vb
+++ b/vbnet/ContextMenu.WinForms/My Project/AssemblyInfo.vb
@@ -1,6 +1,6 @@
-#Region "Copyright"
+﻿#Region "Copyright"
 
-' Copyright 2021, TeamDev. All rights reserved.
+' Copyright © 2021, TeamDev. All rights reserved.
 ' 
 ' Redistribution and use in source and/or binary forms, with or without
 ' modification, must retain the above copyright notice and the following


### PR DESCRIPTION
In this PR the implementation is switched from ContextMenu to ContextMenuStrip to become usable in .NET Core 3.1 and higher.