### PR TITLE
Simplify engine creation in examples

### DIFF
--- a/csharp/AccessingHttpResponseData/Program.cs
+++ b/csharp/AccessingHttpResponseData/Program.cs
@@ -38,7 +38,7 @@ namespace AccessingHttpResponseData
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/AjaxCallsFilter/Program.cs
+++ b/csharp/AjaxCallsFilter/Program.cs
@@ -40,7 +40,7 @@ namespace AjaxCallsFilter
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/AjaxResponseIntercept/Program.cs
+++ b/csharp/AjaxResponseIntercept/Program.cs
@@ -46,7 +46,7 @@ namespace AjaxResponseIntercept
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/CertificateError/Program.cs
+++ b/csharp/CertificateError/Program.cs
@@ -38,7 +38,7 @@ namespace CertificateError
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/CertificateVerifier/Program.cs
+++ b/csharp/CertificateVerifier/Program.cs
@@ -39,7 +39,7 @@ namespace CertificateVerifier
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/CookieFilter/Program.cs
+++ b/csharp/CookieFilter/Program.cs
@@ -39,7 +39,7 @@ namespace CookieFilter
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/Cookies/Program.cs
+++ b/csharp/Cookies/Program.cs
@@ -39,7 +39,7 @@ namespace Cookies
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DefaultMediaStreamDevice/Program.cs
+++ b/csharp/DefaultMediaStreamDevice/Program.cs
@@ -43,7 +43,7 @@ namespace DefaultMediaStreamDevice
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DomCreateElement/Program.cs
+++ b/csharp/DomCreateElement/Program.cs
@@ -37,7 +37,7 @@ namespace DomCreateElement
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DomCreateEvent/Program.cs
+++ b/csharp/DomCreateEvent/Program.cs
@@ -39,7 +39,7 @@ namespace DomCreateEvent
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DomForm/Program.cs
+++ b/csharp/DomForm/Program.cs
@@ -38,7 +38,7 @@ namespace DomForm
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DomGetAttributes/Program.cs
+++ b/csharp/DomGetAttributes/Program.cs
@@ -38,7 +38,7 @@ namespace DomGetAttributes
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DomGetElements/Program.cs
+++ b/csharp/DomGetElements/Program.cs
@@ -39,7 +39,7 @@ namespace DomGetElements
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/DomQuerySelector/Program.cs
+++ b/csharp/DomQuerySelector/Program.cs
@@ -38,7 +38,7 @@ namespace DomQuerySelector
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/ExecuteCommand/Program.cs
+++ b/csharp/ExecuteCommand/Program.cs
@@ -38,7 +38,7 @@ namespace ExecuteCommand
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/ExecuteJavaScript/Program.cs
+++ b/csharp/ExecuteJavaScript/Program.cs
@@ -32,7 +32,7 @@ namespace ExecuteJavaScript
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/FindText/Program.cs
+++ b/csharp/FindText/Program.cs
@@ -41,7 +41,7 @@ namespace FindText
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/GetFrames/Program.cs
+++ b/csharp/GetFrames/Program.cs
@@ -38,7 +38,7 @@ namespace GetFrames
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/GetHtml/Program.cs
+++ b/csharp/GetHtml/Program.cs
@@ -36,7 +36,7 @@ namespace GetHTML
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/GetSelectedText/Program.cs
+++ b/csharp/GetSelectedText/Program.cs
@@ -37,7 +37,7 @@ namespace GetSelectedText
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/InjectObjectForScripting/Program.cs
+++ b/csharp/InjectObjectForScripting/Program.cs
@@ -47,7 +47,7 @@ namespace InjectObjectForScripting
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/Inspect/Program.cs
+++ b/csharp/Inspect/Program.cs
@@ -37,7 +37,7 @@ namespace Inspect
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/JavaScript/Program.cs
+++ b/csharp/JavaScript/Program.cs
@@ -35,7 +35,7 @@ namespace JavaScript
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/JavaScriptBridge.Arrays/Program.cs
+++ b/csharp/JavaScriptBridge.Arrays/Program.cs
@@ -39,7 +39,7 @@ namespace JavaScriptBridge.Arrays
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/JavaScriptBridge/Program.cs
+++ b/csharp/JavaScriptBridge/Program.cs
@@ -45,7 +45,7 @@ namespace JavaScriptBridge
                 LoggerProvider.Instance.Level = SourceLevels.Information;
                 LoggerProvider.Instance.FileLoggingEnabled = true;
                 LoggerProvider.Instance.OutputFile = "dnb.log";
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/JavaScriptObjects/Program.cs
+++ b/csharp/JavaScriptObjects/Program.cs
@@ -36,7 +36,7 @@ namespace JavaScriptObjects
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/LoadEvents/Program.cs
+++ b/csharp/LoadEvents/Program.cs
@@ -37,7 +37,7 @@ namespace LoadEvents
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/NetworkHandlers/Program.cs
+++ b/csharp/NetworkHandlers/Program.cs
@@ -41,7 +41,7 @@ namespace NetworkHandlers
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/PostData/Program.cs
+++ b/csharp/PostData/Program.cs
@@ -41,7 +41,7 @@ namespace PostData
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/ShadowDom/Program.cs
+++ b/csharp/ShadowDom/Program.cs
@@ -39,7 +39,7 @@ namespace ShadowDom
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/WebStorage/Program.cs
+++ b/csharp/WebStorage/Program.cs
@@ -39,7 +39,7 @@ namespace WebStorage
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/XPath/Program.cs
+++ b/csharp/XPath/Program.cs
@@ -39,7 +39,7 @@ namespace XPath
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/csharp/Zoom/Program.cs
+++ b/csharp/Zoom/Program.cs
@@ -38,7 +38,7 @@ namespace Zoom
         {
             try
             {
-                using (IEngine engine = EngineFactory.Create(new EngineOptions.Builder().Build()))
+                using (IEngine engine = EngineFactory.Create())
                 {
                     Console.WriteLine("Engine created");
 

--- a/vbnet/AccessingHttpResponseData/Program.vb
+++ b/vbnet/AccessingHttpResponseData/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/AjaxCallsFilter/Program.vb
+++ b/vbnet/AjaxCallsFilter/Program.vb
@@ -36,7 +36,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/CertificateError/Program.vb
+++ b/vbnet/CertificateError/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/CertificateVerifier/Program.vb
+++ b/vbnet/CertificateVerifier/Program.vb
@@ -37,7 +37,7 @@ Public Class WindowMain
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/CookieFilter/Program.vb
+++ b/vbnet/CookieFilter/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/Cookies/Program.vb
+++ b/vbnet/Cookies/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Dim cookieStorage As ICookieStore = engine.Profiles.Default.CookieStore

--- a/vbnet/DefaultMediaStreamDevice/Program.vb
+++ b/vbnet/DefaultMediaStreamDevice/Program.vb
@@ -38,7 +38,7 @@ Public Class WindowMain
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/DomCreateElement/Program.vb
+++ b/vbnet/DomCreateElement/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/DomCreateEvent/Program.vb
+++ b/vbnet/DomCreateEvent/Program.vb
@@ -36,7 +36,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/DomForm/Program.vb
+++ b/vbnet/DomForm/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/DomGetAttributes/Program.vb
+++ b/vbnet/DomGetAttributes/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/DomGetElements/Program.vb
+++ b/vbnet/DomGetElements/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/DomQuerySelector/Program.vb
+++ b/vbnet/DomQuerySelector/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/ExecuteCommand/Program.vb
+++ b/vbnet/ExecuteCommand/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/ExecuteJavaScript/Program.vb
+++ b/vbnet/ExecuteJavaScript/Program.vb
@@ -29,7 +29,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/FindText/Program.vb
+++ b/vbnet/FindText/Program.vb
@@ -38,7 +38,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/GetFrames/Program.vb
+++ b/vbnet/GetFrames/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/GetHtml/Program.vb
+++ b/vbnet/GetHtml/Program.vb
@@ -33,7 +33,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/GetSelectedText/Program.vb
+++ b/vbnet/GetSelectedText/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/Inspect/Program.vb
+++ b/vbnet/Inspect/Program.vb
@@ -33,7 +33,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/JavaScript/Program.vb
+++ b/vbnet/JavaScript/Program.vb
@@ -32,7 +32,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/JavaScriptBridge/Program.vb
+++ b/vbnet/JavaScriptBridge/Program.vb
@@ -40,7 +40,7 @@ Friend Class Program
             LoggerProvider.Instance.Level = SourceLevels.Information
             LoggerProvider.Instance.FileLoggingEnabled = True
             LoggerProvider.Instance.OutputFile = "dnb.log"
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/JavaScriptObjects/Program.vb
+++ b/vbnet/JavaScriptObjects/Program.vb
@@ -33,7 +33,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/LoadEvents/Program.vb
+++ b/vbnet/LoadEvents/Program.vb
@@ -34,7 +34,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/NetworkHandlers/Program.vb
+++ b/vbnet/NetworkHandlers/Program.vb
@@ -36,7 +36,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/PostData/Program.vb
+++ b/vbnet/PostData/Program.vb
@@ -36,7 +36,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser = engine.CreateBrowser()

--- a/vbnet/WebStorage/Program.vb
+++ b/vbnet/WebStorage/Program.vb
@@ -36,7 +36,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/XPath/Program.vb
+++ b/vbnet/XPath/Program.vb
@@ -36,7 +36,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()

--- a/vbnet/Zoom/Program.vb
+++ b/vbnet/Zoom/Program.vb
@@ -35,7 +35,7 @@ Friend Class Program
 
     Public Shared Sub Main()
         Try
-            Using engine As IEngine = EngineFactory.Create(New EngineOptions.Builder().Build())
+            Using engine As IEngine = EngineFactory.Create()
                 Console.WriteLine("Engine created")
 
                 Using browser As IBrowser = engine.CreateBrowser()


### PR DESCRIPTION
The `EngineFactory.Create(new EngineOptions.Builder().Build())` is replaced with its alias `EngineFactory.Create()`