### PR TITLE
Add HtmlToImage.SkiaSharp example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,4 @@ UpgradeLog*.htm
 NuGet.Config
 
 #Ignore Visual Studio cache
-/csharp/.vs
-/vbnet/.vs
-/csharp/MyOutlookAddIn/.vs
-/vbnet/MyOutlookAddIn/.vs
+*.vs

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To learn more about the library please visit the [product page](https://www.team
 * Save web page: [C#](csharp/SaveWebPage.Wpf), [VB.NET](vbnet/SaveWebPage.Wpf)
 * Save an image from the web page: [C#](csharp/SaveImageFromPage/Program.cs), [VB.NET](vbnet/SaveImageFromPage/Program.vb)
 * Create web page screenshot: [C#](csharp/HtmlToImage/Program.cs), [VB.NET](vbnet/HtmlToImage/Program.vb)
+* Create web page screenshot (cross-platform, uses SkiaSharp): [C#](csharp/HtmlToImage.SkiaSharp/Program.cs), [VB.NET](vbnet/HtmlToImage.SkiaSharp/Program.vb)
 * Execute editor commands (Cut, Copy, Paste, Undo, Select All,<br/> Insert Text etc.): [C#](csharp/ExecuteCommand/Program.cs), [VB.NET](vbnet/ExecuteCommand/Program.vb)
 * Access local storage of the web page: [C#](csharp/WebStorage), [VB.NET](vbnet/WebStorage/Program.vb)
 * Update the zoom level on the web page: [C#](csharp/Zoom/Program.cs), [VB.NET](vbnet/Zoom/Program.vb)

--- a/csharp/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.csproj
+++ b/csharp/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetBrowser.CrossPlatform" Version="2.17.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+  </ItemGroup>
+
+</Project>

--- a/csharp/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.sln
+++ b/csharp/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HtmlToImage.SkiaSharp", "HtmlToImage.SkiaSharp.csproj", "{D9ADE947-C43A-4790-A3FA-C19B5B2C4F13}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D9ADE947-C43A-4790-A3FA-C19B5B2C4F13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9ADE947-C43A-4790-A3FA-C19B5B2C4F13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9ADE947-C43A-4790-A3FA-C19B5B2C4F13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9ADE947-C43A-4790-A3FA-C19B5B2C4F13}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {080C5D04-4819-4FE4-A956-5FD190FF8C57}
+	EndGlobalSection
+EndGlobal

--- a/csharp/HtmlToImage.SkiaSharp/Program.cs
+++ b/csharp/HtmlToImage.SkiaSharp/Program.cs
@@ -26,6 +26,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using DotNetBrowser.Browser;
 using DotNetBrowser.Engine;
+using DotNetBrowser.Geometry;
+using DotNetBrowser.Ui;
 using SkiaSharp;
 
 /// <summary>
@@ -35,7 +37,7 @@ using SkiaSharp;
 
 uint viewWidth = 1024;
 uint viewHeight = 20000;
-DotNetBrowser.Geometry.Size browserSize = new DotNetBrowser.Geometry.Size(viewWidth, viewHeight);
+Size browserSize = new Size(viewWidth, viewHeight);
 
 using(IEngine engine = EngineFactory.Create(new EngineOptions.Builder
 {
@@ -57,7 +59,7 @@ using(IEngine engine = EngineFactory.Create(new EngineOptions.Builder
 
         // 3. Take the bitmap of the currently loaded web page. Its size will be 
         // equal to the current browser's size.
-        DotNetBrowser.Ui.Bitmap image = browser.TakeImage();
+        Bitmap image = browser.TakeImage();
         Console.WriteLine("Browser image taken");
 
         // 4. Convert the bitmap to the required format and save it.
@@ -74,7 +76,7 @@ using(IEngine engine = EngineFactory.Create(new EngineOptions.Builder
 }
 
 // #docfragment "HtmlToImage.SKBitmap.Conversion"
-static SKBitmap ToSKBitmap(DotNetBrowser.Ui.Bitmap browserBitmap)
+static SKBitmap ToSKBitmap(Bitmap browserBitmap)
 {
     int width = (int)browserBitmap.Size.Width;
     int height = (int)browserBitmap.Size.Height;

--- a/csharp/HtmlToImage.SkiaSharp/Program.cs
+++ b/csharp/HtmlToImage.SkiaSharp/Program.cs
@@ -1,0 +1,94 @@
+#region Copyright
+
+// Copyright © 2022, TeamDev. All rights reserved.
+// 
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using DotNetBrowser.Browser;
+using DotNetBrowser.Engine;
+using SkiaSharp;
+
+/// <summary>
+///     This example demonstrates how to get a screenshot of the web page
+///     and save it as a PNG image using SkiaSharp.
+/// </summary>
+
+uint viewWidth = 1024;
+uint viewHeight = 20000;
+DotNetBrowser.Geometry.Size browserSize = new DotNetBrowser.Geometry.Size(viewWidth, viewHeight);
+
+using(IEngine engine = EngineFactory.Create(new EngineOptions.Builder
+{
+    RenderingMode = RenderingMode.OffScreen,
+    ChromiumSwitches = { "--disable-gpu", "--max-texture-size=" + viewHeight }
+}.Build()))
+{
+    using(IBrowser browser = engine.CreateBrowser())
+    {
+        // #docfragment "HtmlToImage.SkiaSharp"
+        // 1. Resize browser to the required dimension.
+        browser.Size = browserSize;
+
+        // 2. Load the required web page and wait until it is loaded completely.
+        Console.WriteLine("Loading https://www.teamdev.com/dotnetbrowser");
+        browser.Navigation
+                .LoadUrl("https://www.teamdev.com/dotnetbrowser")
+                .Wait();
+
+        // 3. Take the bitmap of the currently loaded web page. Its size will be 
+        // equal to the current browser's size.
+        DotNetBrowser.Ui.Bitmap image = browser.TakeImage();
+        Console.WriteLine("Browser image taken");
+
+        // 4. Convert the bitmap to the required format and save it.
+        SKBitmap skBitmap = ToSKBitmap(image);
+
+        using(var stream = File.OpenWrite(Path.GetFullPath("screenshot.png"))) 
+        {
+            SKData d = SKImage.FromBitmap(skBitmap).Encode(SKEncodedImageFormat.Png, 100);
+            d.SaveTo(stream); 
+        }
+        // #enddocfragment "HtmlToImage.SkiaSharp"
+    }
+    Console.WriteLine("Browser image saved");
+}
+
+// #docfragment "HtmlToImage.SKBitmap.Conversion"
+static SKBitmap ToSKBitmap(DotNetBrowser.Ui.Bitmap browserBitmap)
+{
+    int width = (int)browserBitmap.Size.Width;
+    int height = (int)browserBitmap.Size.Height;
+
+    byte[] data = browserBitmap.Pixels.ToArray();
+    SKBitmap bitmap = new();
+    GCHandle gcHandle = 
+        GCHandle.Alloc(data, GCHandleType.Pinned);
+    SKImageInfo info = new(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+
+    IntPtr ptr = gcHandle.AddrOfPinnedObject();
+    int rowBytes = info.RowBytes;
+    bitmap.InstallPixels(info, ptr, rowBytes, delegate { gcHandle.Free(); });
+
+    return bitmap;
+}
+// #enddocfragment "HtmlToImage.SKBitmap.Conversion"

--- a/vbnet/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.sln
+++ b/vbnet/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "HtmlToImage.SkiaSharp", "HtmlToImage.SkiaSharp.vbproj", "{F0E5C96C-D90B-4E52-8443-BDCB5CD05405}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F0E5C96C-D90B-4E52-8443-BDCB5CD05405}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0E5C96C-D90B-4E52-8443-BDCB5CD05405}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0E5C96C-D90B-4E52-8443-BDCB5CD05405}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0E5C96C-D90B-4E52-8443-BDCB5CD05405}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6B7ABBE1-BE84-433E-B814-C3AA65BE3C4E}
+	EndGlobalSection
+EndGlobal

--- a/vbnet/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.vbproj
+++ b/vbnet/HtmlToImage.SkiaSharp/HtmlToImage.SkiaSharp.vbproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetBrowser.CrossPlatform" Version="2.17.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+  </ItemGroup>
+
+</Project>

--- a/vbnet/HtmlToImage.SkiaSharp/Program.vb
+++ b/vbnet/HtmlToImage.SkiaSharp/Program.vb
@@ -1,0 +1,96 @@
+#Region "Copyright"
+
+' Copyright © 2022, TeamDev. All rights reserved.
+' 
+' Redistribution and use in source and/or binary forms, with or without
+' modification, must retain the above copyright notice and the following
+' disclaimer.
+' 
+' THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+' "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+' LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+' A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+' OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+' SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+' LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+' DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+' THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+' (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#End Region
+
+Imports System
+Imports System.IO
+Imports System.Linq
+Imports System.Runtime.InteropServices
+Imports DotNetBrowser.Browser
+Imports DotNetBrowser.Engine
+Imports DotNetBrowser.Geometry
+Imports DotNetBrowser.Ui
+Imports SkiaSharp
+
+''' <summary>
+'''     This example demonstrates how to get a screenshot of the web page
+'''     and save it as a PNG image using SkiaSharp.
+''' </summary>
+Friend Class Program
+    Public Shared Sub Main()
+        Dim viewWidth As UInteger = 1024
+        Dim viewHeight As UInteger = 20000
+        Dim browserSize As New Size(viewWidth, viewHeight)
+
+        Dim builder = New EngineOptions.Builder With {
+            .RenderingMode = RenderingMode.OffScreen
+        }
+        builder.ChromiumSwitches.Add("--disable-gpu")
+        builder.ChromiumSwitches.Add("--max-texture-size=" & viewHeight)
+
+        Using engine As IEngine = EngineFactory.Create(builder.Build())
+            Using browser As IBrowser = engine.CreateBrowser()
+                ' #docfragment "HtmlToImage.SkiaSharp"
+                ' 1. Resize browser to the required dimension.
+                browser.Size = browserSize
+
+                ' 2. Load the required web page and wait until it is loaded completely.
+                Console.WriteLine("Loading https://www.teamdev.com/dotnetbrowser")
+                browser.Navigation.LoadUrl("https://www.teamdev.com/dotnetbrowser").Wait()
+
+                ' 3. Take the bitmap of the currently loaded web page. Its size will be 
+                ' equal to the current browser's size.
+                Dim image As Bitmap = browser.TakeImage()
+                Console.WriteLine("Browser image taken")
+
+                ' 4. Convert the bitmap to the required format and save it.
+                Dim skBitmap As SKBitmap = ToSKBitmap(image)
+
+                Using stream = File.OpenWrite(Path.GetFullPath("screenshot.png"))
+                    Dim d As SKData = SKImage.FromBitmap(skBitmap).Encode(SKEncodedImageFormat.Png, 100)
+                    d.SaveTo(stream)
+                End Using
+                Console.WriteLine("Browser image saved")
+                ' #enddocfragment "HtmlToImage.SkiaSharp"
+            End Using
+        End Using
+    End Sub
+
+    ' #docfragment "HtmlToImage.SKBitmap.Conversion"
+    Public Shared Function ToSKBitmap(browserBitmap As DotNetBrowser.Ui.Bitmap) As SKBitmap
+
+        Dim width = CInt(browserBitmap.Size.Width)
+        Dim height = CInt(browserBitmap.Size.Height)
+
+        Dim data() As Byte = browserBitmap.Pixels.ToArray()
+        Dim bitmap As SKBitmap = New SKBitmap()
+        Dim gcHandle As GCHandle =
+            GCHandle.Alloc(data, GCHandleType.Pinned)
+        Dim info As SKImageInfo = New SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul)
+
+        Dim ptr As IntPtr = gcHandle.AddrOfPinnedObject()
+        Dim rowBytes = info.RowBytes
+        bitmap.InstallPixels(info, ptr, rowBytes, Sub() gcHandle.Free())
+
+        Return bitmap
+    End Function
+    ' #enddocfragment "HtmlToImage.SKBitmap.Conversion"
+End Class


### PR DESCRIPTION
This PR adds HtmlToImage.SkiaSharp example, which works cross-platform.