### PR TITLE
Bump @bufbuild/protobuf and @connectrpc/connect in /csharp/web-ui/reactexample

### DIFF
--- a/csharp/web-ui/reactexample/package-lock.json
+++ b/csharp/web-ui/reactexample/package-lock.json
@@ -8,9 +8,9 @@
       "name": "web-app",
       "version": "0.0.0",
       "dependencies": {
-        "@bufbuild/protobuf": "2.2.1",
-        "@connectrpc/connect": "2.0.0-rc.2",
-        "@connectrpc/connect-web": "2.0.0-rc.2",
+        "@bufbuild/protobuf": "2.12.1",
+        "@connectrpc/connect": "2.1.2",
+        "@connectrpc/connect-web": "2.1.2",
         "@hookform/resolvers": "3.9.1",
         "@radix-ui/react-aspect-ratio": "1.1.11",
         "@radix-ui/react-avatar": "1.1.1",
@@ -42,7 +42,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "1.46.0",
-        "@bufbuild/protoc-gen-es": "2.2.1",
+        "@bufbuild/protoc-gen-es": "2.12.1",
         "@types/cors": "2.8.17",
         "@types/express": "4.17.21",
         "@types/node": "*",
@@ -210,29 +210,29 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.1.tgz",
-      "integrity": "sha512-gdWzq7eX017a1kZCU/bP/sbk4e0GZ6idjsXOcMrQwODCb/rx985fHJJ8+hCu79KpuG7PfZh7bo3BBjPH37JuZw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoc-gen-es": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-2.2.1.tgz",
-      "integrity": "sha512-ysaQTf52lYQTdK0zWpfgxKHVQqCoSe6TV3rD+JZUbiyqT4zloII7VZqmAWXoHk0SZiWdCIvkzMIHQpBxN7v6nA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoc-gen-es/-/protoc-gen-es-2.12.1.tgz",
+      "integrity": "sha512-SWa7XvRYRouMo+vBQmpNFZ+ZEqQ8AC0LpL4QWAo1gvstLhFh/Y7Nf/a+MK7ZxDq5LZSThwfk974L1sFxO3OaGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.2.1",
-        "@bufbuild/protoplugin": "2.2.1"
+        "@bufbuild/protobuf": "2.12.1",
+        "@bufbuild/protoplugin": "2.12.1"
       },
       "bin": {
         "protoc-gen-es": "bin/protoc-gen-es"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "2.2.1"
+        "@bufbuild/protobuf": "2.12.1"
       },
       "peerDependenciesMeta": {
         "@bufbuild/protobuf": {
@@ -241,14 +241,14 @@
       }
     },
     "node_modules/@bufbuild/protoplugin": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-2.2.1.tgz",
-      "integrity": "sha512-dyHRQeUSwMIKSoZZ4l6CuXnggdwf3qlAMppHeKObK1OD++4qdhTveDGmTC+ASFF3IZkoxSYPUq+3e3OdRIKCYg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protoplugin/-/protoplugin-2.12.1.tgz",
+      "integrity": "sha512-PY58KxQVAD1BnnKtStOctsMoegEVGfBnY5AOqVQOIu711nA13oYtTqJM8df5lUQg2J1DR3XxUXptE+fWX5oLdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "2.2.1",
-        "@typescript/vfs": "^1.5.2",
+        "@bufbuild/protobuf": "2.12.1",
+        "@typescript/vfs": "^1.6.2",
         "typescript": "5.4.5"
       }
     },
@@ -267,22 +267,22 @@
       }
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.2.tgz",
-      "integrity": "sha512-EBXUD82U1Z6eWhFu+90ZvuEUCM8K03gV7cGNSQXJ9kDV07dfuvm/LevbzMEsST43Wea6ywYzd2HBNEAPJCxu8g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.2.0"
+        "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.2.tgz",
-      "integrity": "sha512-HMIDXahQtPNcmsLVfHxjKLp4oRz2b89VOCMJpt3zNMd1fzC27Ipf7Wf+7OPmER61xc9mJVkMY0D6XUPw0vB9aQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.2"
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/csharp/web-ui/reactexample/package.json
+++ b/csharp/web-ui/reactexample/package.json
@@ -11,9 +11,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "2.2.1",
-    "@connectrpc/connect": "2.0.0-rc.2",
-    "@connectrpc/connect-web": "2.0.0-rc.2",
+    "@bufbuild/protobuf": "2.12.1",
+    "@connectrpc/connect": "2.1.2",
+    "@connectrpc/connect-web": "2.1.2",
     "@hookform/resolvers": "3.9.1",
     "@radix-ui/react-aspect-ratio": "1.1.11",
     "@radix-ui/react-avatar": "1.1.1",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@bufbuild/buf": "1.46.0",
-    "@bufbuild/protoc-gen-es": "2.2.1",
+    "@bufbuild/protoc-gen-es": "2.12.1",
     "@types/cors": "2.8.17",
     "@types/express": "4.17.21",
     "@types/node": "*",


### PR DESCRIPTION
## Summary
- Combines dependabot #250 and #249, neither of which is safe to merge alone.
- #250 (`@bufbuild/protobuf` 2.2.1 → 2.12.1) leaves `@bufbuild/protoc-gen-es` pinned at 2.2.1, which breaks `buf generate` codegen (`protoc-gen-es: Cannot read properties of undefined (reading 'length')`).
- #249 (`@connectrpc/connect` 2.0.0-rc.2 → 2.1.2) fails `npm install` outright with an ERESOLVE peer-dependency conflict, since `connect@2.1.2` requires `@bufbuild/protobuf@^2.7.0` which the pinned 2.2.1 doesn't satisfy; it also leaves `@connectrpc/connect-web` stuck on the old `2.0.0-rc.2`.
- This PR bumps all four related packages together so peers stay satisfied:
  - `@bufbuild/protobuf` 2.2.1 → 2.12.1
  - `@bufbuild/protoc-gen-es` 2.2.1 → 2.12.1
  - `@connectrpc/connect` 2.0.0-rc.2 → 2.1.2
  - `@connectrpc/connect-web` 2.0.0-rc.2 → 2.1.2

