### PR TITLE
Mark CDP automation fragments for docs embedding

### DIFF
--- a/csharp/devtools-protocol/Playwright/MainWindow.xaml.cs
+++ b/csharp/devtools-protocol/Playwright/MainWindow.xaml.cs
@@ -63,6 +63,7 @@ namespace Playwright
         {
             try
             {
+                // #docfragment "Playwright.Connect"
                 using IPlaywright playwright = await Microsoft.Playwright.Playwright.CreateAsync();
 
                 // Connect to the browser using CDP
@@ -84,6 +85,7 @@ namespace Playwright
 
                 // Scroll the map into view
                 await page.Locator("#map").ScrollIntoViewIfNeededAsync();
+                // #enddocfragment "Playwright.Connect"
             }
             catch (Exception e)
             {

--- a/csharp/devtools-protocol/Puppeteer/MainWindow.xaml.cs
+++ b/csharp/devtools-protocol/Puppeteer/MainWindow.xaml.cs
@@ -64,13 +64,16 @@ namespace Puppeteer
 
         public async Task Connect()
         {
+            // #docfragment "Puppeteer.ConnectOptions"
             ConnectOptions options = new ConnectOptions
             {
                 BrowserURL = $"http://127.0.0.1:{RemoteDebuggingPort}",
             };
+            // #enddocfragment "Puppeteer.ConnectOptions"
 
             try
             {
+                // #docfragment "Puppeteer.Connect"
                 PuppeteerSharp.IBrowser browser =
                     await PuppeteerSharp.Puppeteer.ConnectAsync(options);
 
@@ -88,6 +91,7 @@ namespace Puppeteer
                     Latitude = 42.746635M, Longitude = -75.770045M
                 });
                 await (await page.QuerySelectorAsync("#map")).ScrollIntoViewAsync();
+                // #enddocfragment "Puppeteer.Connect"
             }
             catch (Exception e)
             {

--- a/csharp/devtools-protocol/SeleniumChromeDriver/Form1.cs
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/Form1.cs
@@ -65,6 +65,7 @@ namespace SeleniumChromeDriver
 
         private void InitializeBrowser()
         {
+            // #docfragment "Selenium.EngineOptions"
             EngineOptions engineOptions = new EngineOptions.Builder
                 {
                     ChromiumSwitches =
@@ -78,6 +79,7 @@ namespace SeleniumChromeDriver
 
             engine = EngineFactory.Create(engineOptions);
             browser = engine.CreateBrowser();
+            // #enddocfragment "Selenium.EngineOptions"
 
             byte[] htmlBytes = Encoding.UTF8.GetBytes("<h1>Waiting for Selenium...</h1>");
             browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes));

--- a/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.cs
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.cs
@@ -63,6 +63,7 @@ namespace SeleniumChromeDriver
         {
             return await Task.Run(() =>
             {
+                // #docfragment "Selenium.Connect"
                 ChromeOptions options = new ChromeOptions
                 {
                     BinaryLocation = ApplicationFullPath,
@@ -73,6 +74,7 @@ namespace SeleniumChromeDriver
                 {
                     Url = "https://www.teamdev.com/dotnetbrowser"
                 };
+                // #enddocfragment "Selenium.Connect"
 
                 OnConnected();
 

--- a/vbnet/devtools-protocol/Playwright/MainWindow.xaml.vb
+++ b/vbnet/devtools-protocol/Playwright/MainWindow.xaml.vb
@@ -58,6 +58,7 @@ Public Partial Class MainWindow
 
     Private Async Function ConnectAsync() As Task
         Try
+            ' #docfragment "Playwright.Connect"
             Using _
                 playwright As IPlaywright =
                     Await Microsoft.Playwright.Playwright.CreateAsync()
@@ -81,6 +82,7 @@ Public Partial Class MainWindow
                 ' Scroll the map into view
                 Await page.Locator("#map").ScrollIntoViewIfNeededAsync()
             End Using
+            ' #enddocfragment "Playwright.Connect"
         Catch e As Exception
             Debug.WriteLine(e)
             MessageBox.Show($"Failed to connect: {e.Message}", "Error",

--- a/vbnet/devtools-protocol/Puppeteer/MainWindow.xaml.vb
+++ b/vbnet/devtools-protocol/Puppeteer/MainWindow.xaml.vb
@@ -54,11 +54,14 @@ Public Partial Class MainWindow
     End Sub
 
     Public Async Function Connect() As Task
+        ' #docfragment "Puppeteer.ConnectOptions"
         Dim options As New ConnectOptions With {
                 .BrowserURL = $"http://127.0.0.1:{RemoteDebuggingPort}"
                 }
+        ' #enddocfragment "Puppeteer.ConnectOptions"
 
         Try
+            ' #docfragment "Puppeteer.Connect"
             Dim puppeteerBrowser As IBrowser =
                     Await PuppeteerSharp.Puppeteer.ConnectAsync(options)
 
@@ -76,6 +79,7 @@ Public Partial Class MainWindow
                                               .Longitude = - 75.770045D
                                               })
             Await (Await page.QuerySelectorAsync("#map")).ScrollIntoViewAsync()
+            ' #enddocfragment "Puppeteer.Connect"
 
         Catch e As Exception
             Debug.WriteLine(e)

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/Form1.vb
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/Form1.vb
@@ -59,6 +59,7 @@ Public Class Form1
     End Sub
 
     Private Sub InitializeBrowser()
+        ' #docfragment "Selenium.EngineOptions"
         Dim engineOptionsBuilder As EngineOptions.Builder = new EngineOptions.Builder
         With engineOptionsBuilder
             .WebSecurityDisabled = True
@@ -70,6 +71,7 @@ Public Class Form1
 
         engine = EngineFactory.Create(engineOptions)
         browser = engine.CreateBrowser()
+        ' #enddocfragment "Selenium.EngineOptions"
 
         Dim htmlBytes() As Byte = Encoding.UTF8.GetBytes("<h1>Waiting for Selenium...</h1>")
         browser.Navigation.LoadUrl("data:text/html;base64," + Convert.ToBase64String(htmlBytes))

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.vb
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.vb
@@ -48,6 +48,7 @@ Public Class SeleniumInstance
     End Function
 
     Private Async Function ConnectAsync() As Task(Of IWebDriver)
+        ' #docfragment "Selenium.Connect"
         Dim options As ChromeOptions = new ChromeOptions
         With options
             .BinaryLocation = ApplicationFullPath
@@ -58,6 +59,7 @@ Public Class SeleniumInstance
         With webDriver
             .Url = "https://www.teamdev.com/dotnetbrowser"
         End With
+        ' #enddocfragment "Selenium.Connect"
 
         RaiseEvent Connected
 


### PR DESCRIPTION
Add #docfragment markers to the devtools-protocol examples so the new Automation tutorials in DotNetBrowser-Docs can embed them instead of duplicating the code:

- Selenium.EngineOptions, Selenium.Connect
- Playwright.Connect
- Puppeteer.ConnectOptions, Puppeteer.Connect

Comments only; no logic changes.