### PR TITLE
Use an array initializer in the Playwright example

### DIFF
--- a/csharp/devtools-protocol/Playwright/MainWindow.xaml.cs
+++ b/csharp/devtools-protocol/Playwright/MainWindow.xaml.cs
@@ -72,7 +72,7 @@ namespace Playwright
                                     .ConnectOverCDPAsync($"http://localhost:{RemoteDebuggingPort}");
 
                 IBrowserContext browserContext = playwrightBrowser.Contexts[0];
-                await browserContext.GrantPermissionsAsync(["geolocation"]);
+                await browserContext.GrantPermissionsAsync(new[] { "geolocation" });
                 await browserContext.SetGeolocationAsync(new Geolocation
                 {
                     Latitude = 42.746635f,


### PR DESCRIPTION
Replaces the collection expression in the Playwright example with an array
initializer:

```csharp
-await browserContext.GrantPermissionsAsync(["geolocation"]);
+await browserContext.GrantPermissionsAsync(new[] { "geolocation" });
```
