### PR TITLE
Unsubscribe the focus handler when the context menu closes

### DIFF
--- a/csharp/avalonia/ContextMenu/MainWindow.axaml.cs
+++ b/csharp/avalonia/ContextMenu/MainWindow.axaml.cs
@@ -138,6 +138,7 @@ namespace ContextMenu
 
                 cm.Closed += (sender, args) =>
                 {
+                    browser.FocusRequested -= onFocusRequested;
                     browser.Focus();
                     tcs.TrySetResult(ShowContextMenuResponse.Close());
                 };

--- a/csharp/winforms/ContextMenu.SpellCheck/Form1.cs
+++ b/csharp/winforms/ContextMenu.SpellCheck/Form1.cs
@@ -169,6 +169,7 @@ namespace ContextMenu.SpellCheck.WinForms
                             tcs.TrySetResult(ShowContextMenuResponse.Close());
                         }
 
+                        parameters.Browser.FocusRequested -= onFocusRequested;
                         popupMenu.Closed -= menuOnClosed;
                     };
                     popupMenu.Closed += menuOnClosed;

--- a/csharp/winforms/ContextMenu/Form1.cs
+++ b/csharp/winforms/ContextMenu/Form1.cs
@@ -151,6 +151,7 @@ namespace ContextMenu.WinForms
                             tcs.TrySetResult(ShowContextMenuResponse.Close());
                         }
 
+                        parameters.Browser.FocusRequested -= onFocusRequested;
                         popupMenu.Closed -= menuOnClosed;
                     };
                     popupMenu.Closed += menuOnClosed;

--- a/vbnet/winforms/ContextMenu.SpellCheck/Form1.vb
+++ b/vbnet/winforms/ContextMenu.SpellCheck/Form1.vb
@@ -149,6 +149,7 @@ Partial Public Class Form1
                         tcs.TrySetResult(ShowContextMenuResponse.Close())
                     End If
 
+                    RemoveHandler parameters.Browser.FocusRequested, onFocusRequested
                     RemoveHandler popupMenu.Closed, menuOnClosed
                 End Sub
                 AddHandler popupMenu.Closed, menuOnClosed

--- a/vbnet/winforms/ContextMenu/Form1.vb
+++ b/vbnet/winforms/ContextMenu/Form1.vb
@@ -132,6 +132,7 @@ Partial Public Class Form1
                         tcs.TrySetResult(ShowContextMenuResponse.Close())
                     End If
 
+                    RemoveHandler parameters.Browser.FocusRequested, onFocusRequested
                     RemoveHandler popupMenu.Closed, menuOnClosed
                 End Sub
                 AddHandler popupMenu.Closed, menuOnClosed


### PR DESCRIPTION
The context menu examples close the menu when the browser asks for focus back:

```csharp
EventHandler<FocusRequestedEventArgs> onFocusRequested = null;
onFocusRequested = (sender, args) =>
{
    BeginInvoke((Action) (() => popupMenu.Close()));
    parameters.Browser.FocusRequested -= onFocusRequested;
};
parameters.Browser.FocusRequested += onFocusRequested;
```

The handler removes itself, but only when a focus request actually arrives. A
focus request is just one of the ways the menu closes — clicking an item or
clicking away closes it too, and on those paths the subscription survives.
Every context menu the user opens leaves one more handler attached, and those
handlers keep firing, each trying to close a menu that has already closed.

The close handler already unsubscribes itself, so this adds the focus handler
next to it:

```csharp
parameters.Browser.FocusRequested -= onFocusRequested;
popupMenu.Closed -= menuOnClosed;
```

Removing a handler that is not attached is a no-op, so the existing
unsubscribe inside `onFocusRequested` is harmless and stays.
