### PR TITLE
Drop settings the Selenium example does not need

### DIFF
--- a/csharp/devtools-protocol/SeleniumChromeDriver/Form1.cs
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/Form1.cs
@@ -68,11 +68,6 @@ namespace SeleniumChromeDriver
             // #docfragment "Selenium.EngineOptions"
             EngineOptions engineOptions = new EngineOptions.Builder
                 {
-                    ChromiumSwitches =
-                    {
-                        "--enable-automation"
-                    },
-                    WebSecurityDisabled = true,
                     RemoteDebuggingPort = RemoteDebuggingPort
                 }
                .Build();

--- a/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.cs
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.cs
@@ -21,7 +21,6 @@
 #endregion
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -30,14 +29,12 @@ namespace SeleniumChromeDriver
 {
     public class SeleniumInstance
     {
-        private string ApplicationFullPath { get; }
         private string RemoteDebuggingAddress { get; }
 
         public event Action Connected;
 
         public SeleniumInstance(int debuggingPort)
         {
-            ApplicationFullPath = Process.GetCurrentProcess()?.MainModule?.FileName;
             RemoteDebuggingAddress = $"localhost:{debuggingPort}";
         }
 
@@ -66,7 +63,6 @@ namespace SeleniumChromeDriver
                 // #docfragment "Selenium.Connect"
                 ChromeOptions options = new ChromeOptions
                 {
-                    BinaryLocation = ApplicationFullPath,
                     DebuggerAddress = RemoteDebuggingAddress
                 };
 

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/Form1.vb
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/Form1.vb
@@ -62,9 +62,7 @@ Public Class Form1
         ' #docfragment "Selenium.EngineOptions"
         Dim engineOptionsBuilder As EngineOptions.Builder = new EngineOptions.Builder
         With engineOptionsBuilder
-            .WebSecurityDisabled = True
             .RemoteDebuggingPort = RemoteDebuggingPort
-            .ChromiumSwitches.Add("--enable-automation")
         End With
 
         Dim engineOptions = engineOptionsBuilder.Build()

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.vb
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.vb
@@ -25,13 +25,11 @@ Imports OpenQA.Selenium.Chrome
 
 Public Class SeleniumInstance
     
-    Private ApplicationFullPath as String
     Private RemoteDebuggingAddress as String
 
     Public Event Connected As Action
 
     Public Sub New(debuggingPort As Integer)
-        ApplicationFullPath = Process.GetCurrentProcess().MainModule.FileName
         RemoteDebuggingAddress = $"localhost:{debuggingPort}"
     End Sub
 
@@ -51,7 +49,6 @@ Public Class SeleniumInstance
         ' #docfragment "Selenium.Connect"
         Dim options As ChromeOptions = new ChromeOptions
         With options
-            .BinaryLocation = ApplicationFullPath
             .DebuggerAddress = RemoteDebuggingAddress
         End With
 


### PR DESCRIPTION
The Selenium example configured three things it does not need:

- `--enable-automation` in `ChromiumSwitches`
- `WebSecurityDisabled = true`
- `BinaryLocation` on `ChromeOptions`

All three appear to be carried over from the DotNetBrowser 1 version of this
example, which launched a separate process and passed `--disable-web-security`
and `--enable-automation` as raw Chromium switches. Attaching to an engine in
the same process needs none of them.



