### PR TITLE
Drive a bundled page in the Selenium example

### DIFF
--- a/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumChromeDriver.csproj
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumChromeDriver.csproj
@@ -105,6 +105,12 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Content Include="home.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="contact.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.cs
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.cs
@@ -21,6 +21,7 @@
 #endregion
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -30,6 +31,14 @@ namespace SeleniumChromeDriver
     public class SeleniumInstance
     {
         private string RemoteDebuggingAddress { get; }
+
+        /// <summary>
+        ///     The page shipped alongside the application, so that the
+        ///     scenario does not depend on an external web site.
+        /// </summary>
+        private static string StartPage =>
+            new Uri(Path.Combine(Directory.GetCurrentDirectory(), "home.html"))
+               .AbsoluteUri;
 
         public event Action Connected;
 
@@ -68,8 +77,12 @@ namespace SeleniumChromeDriver
 
                 IWebDriver webDriver = new ChromeDriver(options)
                 {
-                    Url = "https://www.teamdev.com/dotnetbrowser"
+                    Url = StartPage
                 };
+
+                // Give FindElement time to wait for the page to load.
+                webDriver.Manage().Timeouts().ImplicitWait =
+                    TimeSpan.FromSeconds(10);
                 // #enddocfragment "Selenium.Connect"
 
                 OnConnected();
@@ -82,13 +95,13 @@ namespace SeleniumChromeDriver
         {
             await Task.Run(() =>
             {
-                IWebElement evaluateButton = webDriver.FindElement(By.CssSelector(".nav-container > nav:nth-child(2) > ul:nth-child(1) > li:nth-child(6) > a:nth-child(1)"));
-                evaluateButton.Click();
+                IWebElement evaluateLink = webDriver.FindElement(By.Id("evaluate"));
+                evaluateLink.Click();
 
-                IWebElement nameTextbox = webDriver.FindElement(By.XPath("/html/body/div[1]/div[1]/div[11]/div[1]/div/div[2]/form/input[1]"));
+                IWebElement nameTextbox = webDriver.FindElement(By.Id("name"));
                 nameTextbox.SendKeys("John Doe");
 
-                IWebElement emailTextbox = webDriver.FindElement(By.XPath("/html/body/div[1]/div[1]/div[11]/div[1]/div/div[2]/form/input[2]"));
+                IWebElement emailTextbox = webDriver.FindElement(By.Id("email"));
                 emailTextbox.SendKeys("sales@teamdev.com");
             });
         }

--- a/csharp/devtools-protocol/SeleniumChromeDriver/contact.html
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/contact.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Request an evaluation</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; color: #222; }
+        label { display: block; margin-top: 1rem; }
+        input { font-size: 1rem; padding: 0.3rem; width: 18rem; }
+    </style>
+</head>
+<body>
+<h1>Request an evaluation</h1>
+<p>Selenium fills this form in.</p>
+<form onsubmit="return false">
+    <label for="name">Name</label>
+    <input type="text" id="name">
+    <label for="email">Email</label>
+    <input type="email" id="email">
+</form>
+</body>
+</html>

--- a/csharp/devtools-protocol/SeleniumChromeDriver/home.html
+++ b/csharp/devtools-protocol/SeleniumChromeDriver/home.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>DotNetBrowser and Selenium</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; color: #222; }
+        a { font-size: 1.1rem; }
+    </style>
+</head>
+<body>
+<h1>DotNetBrowser and Selenium</h1>
+<p>
+    This page runs in the browser embedded in the application. Selenium
+    WebDriver is attached to it over the DevTools Protocol.
+</p>
+<p><a id="evaluate" href="contact.html">Request an evaluation</a></p>
+</body>
+</html>

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumChromeDriver.vbproj
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumChromeDriver.vbproj
@@ -170,6 +170,12 @@
       <LastGenOutput>Settings.Designer.vb</LastGenOutput>
     </None>
     <None Include="App.config" />
+    <Content Include="home.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="contact.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.vb
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/SeleniumInstance.vb
@@ -20,12 +20,25 @@
 
 #End Region
 
+Imports System.IO
 Imports OpenQA.Selenium
 Imports OpenQA.Selenium.Chrome
 
 Public Class SeleniumInstance
     
     Private RemoteDebuggingAddress as String
+
+    ''' <summary>
+    '''     The page shipped alongside the application, so that the scenario
+    '''     does not depend on an external web site.
+    ''' </summary>
+    Private Shared ReadOnly Property StartPage As String
+        Get
+            Return New Uri(
+                Path.Combine(Directory.GetCurrentDirectory(), "home.html")
+                ).AbsoluteUri
+        End Get
+    End Property
 
     Public Event Connected As Action
 
@@ -54,8 +67,11 @@ Public Class SeleniumInstance
 
         Dim webDriver As IWebDriver = new ChromeDriver(options)
         With webDriver
-            .Url = "https://www.teamdev.com/dotnetbrowser"
+            .Url = StartPage
         End With
+
+        ' Give FindElement time to wait for the page to load.
+        webDriver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10)
         ' #enddocfragment "Selenium.Connect"
 
         RaiseEvent Connected
@@ -64,13 +80,13 @@ Public Class SeleniumInstance
     End Function
 
     Private Async Function RunScenarioAsync(webDriver As IWebDriver) As Task
-        Dim evaluateButton As IWebElement = webDriver.FindElement(By.CssSelector(".nav-container > nav:nth-child(2) > ul:nth-child(1) > li:nth-child(6) > a:nth-child(1)"))
-        evaluateButton.Click()
+        Dim evaluateLink As IWebElement = webDriver.FindElement(By.Id("evaluate"))
+        evaluateLink.Click()
 
-        Dim nameTextbox As IWebElement = webDriver.FindElement(By.XPath("/html/body/div[1]/div[1]/div[11]/div[1]/div/div[2]/form/input[1]"))
+        Dim nameTextbox As IWebElement = webDriver.FindElement(By.Id("name"))
         nameTextbox.SendKeys("John Doe")
 
-        Dim emailTextbox As IWebElement = webDriver.FindElement(By.XPath("/html/body/div[1]/div[1]/div[11]/div[1]/div/div[2]/form/input[2]"))
+        Dim emailTextbox As IWebElement = webDriver.FindElement(By.Id("email"))
         emailTextbox.SendKeys("sales@teamdev.com")
     End Function
 

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/contact.html
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/contact.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Request an evaluation</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; color: #222; }
+        label { display: block; margin-top: 1rem; }
+        input { font-size: 1rem; padding: 0.3rem; width: 18rem; }
+    </style>
+</head>
+<body>
+<h1>Request an evaluation</h1>
+<p>Selenium fills this form in.</p>
+<form onsubmit="return false">
+    <label for="name">Name</label>
+    <input type="text" id="name">
+    <label for="email">Email</label>
+    <input type="email" id="email">
+</form>
+</body>
+</html>

--- a/vbnet/devtools-protocol/SeleniumChromeDriver/home.html
+++ b/vbnet/devtools-protocol/SeleniumChromeDriver/home.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>DotNetBrowser and Selenium</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; color: #222; }
+        a { font-size: 1.1rem; }
+    </style>
+</head>
+<body>
+<h1>DotNetBrowser and Selenium</h1>
+<p>
+    This page runs in the browser embedded in the application. Selenium
+    WebDriver is attached to it over the DevTools Protocol.
+</p>
+<p><a id="evaluate" href="contact.html">Request an evaluation</a></p>
+</body>
+</html>


### PR DESCRIPTION
The Selenium example drove `teamdev.com` and located elements like this:

```csharp
By.CssSelector(".nav-container > nav:nth-child(2) > ul:nth-child(1) > li:nth-child(6) > a:nth-child(1)")
By.XPath("/html/body/div[1]/div[1]/div[11]/div[1]/div/div[2]/form/input[1]")
```

Those no longer match the site, so the example fails today regardless of how
the engine is configured — the click throws `NoSuchElementException`. Being
positional, they were always going to break at the next redesign. The scenario
also typed a name and an address into a live form on every run.

## What changes

The example now ships `home.html` and `contact.html` and drives those. The
scenario keeps its shape — open a page, click a link, fill in two fields — but
runs against markup the example owns:

```csharp
IWebElement evaluateLink = webDriver.FindElement(By.Id("evaluate"));
evaluateLink.Click();

IWebElement nameTextbox = webDriver.FindElement(By.Id("name"));
nameTextbox.SendKeys("John Doe");
```

This follows `csharp/winforms/SimulateUserInput`, the closest existing example:
it ships `form1.html` and `form2.html` as `Content` with
`CopyToOutputDirectory=Always` and selects by element id. Ids are the idiom
throughout these examples — `GetElementById("demo")`, `("login")`,
`("firstname")` and so on — and the two positional selectors removed here were
among the very few in the repository.

Also sets an implicit wait, so `FindElement` waits for the second page rather
than racing the navigation the click starts.

