### PR TITLE
Refresh the Google Maps example

### DIFF
--- a/csharp/winforms/GoogleMaps/GoogleMap.cs
+++ b/csharp/winforms/GoogleMaps/GoogleMap.cs
@@ -1,0 +1,106 @@
+#region Copyright
+
+// Copyright © 2026, TeamDev. All rights reserved.
+// 
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+using System;
+using System.Globalization;
+using DotNetBrowser.Frames;
+using DotNetBrowser.Js;
+
+namespace GoogleMaps.WinForms
+{
+    /// <summary>
+    ///     The wrapper class for the <c>google.maps.Map</c> object displayed on the page.
+    /// </summary>
+    internal class GoogleMap
+    {
+        /// <summary>
+        ///     The zoom levels supported by Google Maps.
+        /// </summary>
+        private const int MinZoomLevel = 0;
+        private const int MaxZoomLevel = 21;
+
+        private readonly IJsObject map;
+
+        /// <summary>
+        ///     Gets or sets the zoom level of the map. The value being set is
+        ///     clamped to the range supported by Google Maps.
+        /// </summary>
+        // #docfragment "GoogleMaps.Zoom"
+        public int Zoom
+        {
+            get { return (int) map.Invoke<double>("getZoom"); }
+
+            set
+            {
+                int zoom = Math.Min(MaxZoomLevel, Math.Max(MinZoomLevel, value));
+                map.Invoke("setZoom", zoom);
+            }
+        }
+        // #enddocfragment "GoogleMaps.Zoom"
+
+        private IFrame Frame => map.Frame;
+
+        public GoogleMap(IJsObject jsMap)
+        {
+            map = jsMap ?? throw new ArgumentNullException(nameof(jsMap));
+        }
+
+        /// <summary>
+        ///     Puts a marker at the given position.
+        /// </summary>
+        public void AddMarker(double latitude, double longitude)
+        {
+            // #docfragment "GoogleMaps.AddMarker"
+            // Create the marker in the page context and attach it to the map.
+            IJsObject marker = Frame
+                              .ExecuteJavaScript<IJsObject>(
+                                   "new google.maps.marker.AdvancedMarkerElement({map: map})")
+                              .Result;
+
+            // AdvancedMarkerElement exposes the position as a property rather
+            // than through a setter method.
+            marker.Properties["position"] = ToLatLngLiteral(latitude, longitude);
+            // #enddocfragment "GoogleMaps.AddMarker"
+        }
+
+        /// <summary>
+        ///     Centers the map on the given position.
+        /// </summary>
+        public void SetCenter(double latitude, double longitude)
+        {
+            map.Invoke("setCenter", ToLatLngLiteral(latitude, longitude));
+        }
+
+        /// <summary>
+        ///     Creates a JavaScript <c>LatLngLiteral</c> object for the given coordinates.
+        /// </summary>
+        private object ToLatLngLiteral(double latitude, double longitude)
+        {
+            // The invariant culture is used on purpose: JSON requires a dot as
+            // the decimal separator regardless of the current locale.
+            string json = string.Format(CultureInfo.InvariantCulture,
+                                        "{{ \"lat\": {0}, \"lng\": {1} }}",
+                                        latitude,
+                                        longitude);
+            return Frame.ParseJsonString(json);
+        }
+    }
+}

--- a/csharp/winforms/GoogleMaps/GoogleMaps.WinForms.csproj
+++ b/csharp/winforms/GoogleMaps/GoogleMaps.WinForms.csproj
@@ -82,6 +82,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GoogleMap.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/csharp/winforms/GoogleMaps/MainForm.Designer.cs
+++ b/csharp/winforms/GoogleMaps/MainForm.Designer.cs
@@ -28,13 +28,52 @@ namespace GoogleMaps.WinForms
         /// </summary>
         private void InitializeComponent()
         {
+            this.browserView = new DotNetBrowser.WinForms.BrowserView();
+            this.mapControls = new System.Windows.Forms.FlowLayoutPanel();
             this.ZoomInBtn = new System.Windows.Forms.Button();
             this.ZoomOutBtn = new System.Windows.Forms.Button();
+            this.latitudeLabel = new System.Windows.Forms.Label();
+            this.latitudeValue = new System.Windows.Forms.NumericUpDown();
+            this.longitudeLabel = new System.Windows.Forms.Label();
+            this.longitudeValue = new System.Windows.Forms.NumericUpDown();
+            this.AddMarkerBtn = new System.Windows.Forms.Button();
+            this.MyLocationBtn = new System.Windows.Forms.Button();
+            this.mapControls.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.latitudeValue)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.longitudeValue)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
+            // browserView
+            //
+            this.browserView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.browserView.Location = new System.Drawing.Point(0, 46);
+            this.browserView.Name = "browserView";
+            this.browserView.Size = new System.Drawing.Size(1067, 508);
+            this.browserView.TabIndex = 1;
+            //
+            // mapControls
+            //
+            this.mapControls.Controls.Add(this.ZoomInBtn);
+            this.mapControls.Controls.Add(this.ZoomOutBtn);
+            this.mapControls.Controls.Add(this.latitudeLabel);
+            this.mapControls.Controls.Add(this.latitudeValue);
+            this.mapControls.Controls.Add(this.longitudeLabel);
+            this.mapControls.Controls.Add(this.longitudeValue);
+            this.mapControls.Controls.Add(this.AddMarkerBtn);
+            this.mapControls.Controls.Add(this.MyLocationBtn);
+            this.mapControls.Dock = System.Windows.Forms.DockStyle.Top;
+            // The controls stay disabled until the map reports that it is ready.
+            this.mapControls.Enabled = false;
+            this.mapControls.Location = new System.Drawing.Point(0, 0);
+            this.mapControls.Name = "mapControls";
+            this.mapControls.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.mapControls.Size = new System.Drawing.Size(1067, 46);
+            this.mapControls.TabIndex = 0;
+            this.mapControls.WrapContents = false;
+            //
             // ZoomInBtn
-            // 
-            this.ZoomInBtn.Location = new System.Drawing.Point(927, 15);
+            //
+            this.ZoomInBtn.Location = new System.Drawing.Point(8, 8);
             this.ZoomInBtn.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ZoomInBtn.Name = "ZoomInBtn";
             this.ZoomInBtn.Size = new System.Drawing.Size(100, 28);
@@ -42,10 +81,10 @@ namespace GoogleMaps.WinForms
             this.ZoomInBtn.Text = "Zoom +";
             this.ZoomInBtn.UseVisualStyleBackColor = true;
             this.ZoomInBtn.Click += new System.EventHandler(this.ZoomInBtn_Click);
-            // 
+            //
             // ZoomOutBtn
-            // 
-            this.ZoomOutBtn.Location = new System.Drawing.Point(927, 50);
+            //
+            this.ZoomOutBtn.Location = new System.Drawing.Point(116, 8);
             this.ZoomOutBtn.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.ZoomOutBtn.Name = "ZoomOutBtn";
             this.ZoomOutBtn.Size = new System.Drawing.Size(100, 28);
@@ -53,25 +92,139 @@ namespace GoogleMaps.WinForms
             this.ZoomOutBtn.Text = "Zoom -";
             this.ZoomOutBtn.UseVisualStyleBackColor = true;
             this.ZoomOutBtn.Click += new System.EventHandler(this.ZoomOutBtn_Click);
-            // 
+            //
+            // latitudeLabel
+            //
+            this.latitudeLabel.AutoSize = true;
+            this.latitudeLabel.Location = new System.Drawing.Point(240, 14);
+            this.latitudeLabel.Margin = new System.Windows.Forms.Padding(20, 10, 4, 4);
+            this.latitudeLabel.Name = "latitudeLabel";
+            this.latitudeLabel.Size = new System.Drawing.Size(62, 17);
+            this.latitudeLabel.TabIndex = 2;
+            this.latitudeLabel.Text = "Latitude:";
+            //
+            // latitudeValue
+            //
+            this.latitudeValue.DecimalPlaces = 6;
+            this.latitudeValue.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            this.latitudeValue.Location = new System.Drawing.Point(310, 8);
+            this.latitudeValue.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.latitudeValue.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.latitudeValue.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.latitudeValue.Name = "latitudeValue";
+            this.latitudeValue.Size = new System.Drawing.Size(120, 22);
+            this.latitudeValue.TabIndex = 3;
+            this.latitudeValue.Value = new decimal(new int[] {
+            48209331,
+            0,
+            0,
+            393216});
+            //
+            // longitudeLabel
+            //
+            this.longitudeLabel.AutoSize = true;
+            this.longitudeLabel.Location = new System.Drawing.Point(454, 14);
+            this.longitudeLabel.Margin = new System.Windows.Forms.Padding(20, 10, 4, 4);
+            this.longitudeLabel.Name = "longitudeLabel";
+            this.longitudeLabel.Size = new System.Drawing.Size(72, 17);
+            this.longitudeLabel.TabIndex = 4;
+            this.longitudeLabel.Text = "Longitude:";
+            //
+            // longitudeValue
+            //
+            this.longitudeValue.DecimalPlaces = 6;
+            this.longitudeValue.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            this.longitudeValue.Location = new System.Drawing.Point(534, 8);
+            this.longitudeValue.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.longitudeValue.Maximum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            0});
+            this.longitudeValue.Minimum = new decimal(new int[] {
+            180,
+            0,
+            0,
+            -2147483648});
+            this.longitudeValue.Name = "longitudeValue";
+            this.longitudeValue.Size = new System.Drawing.Size(120, 22);
+            this.longitudeValue.TabIndex = 5;
+            this.longitudeValue.Value = new decimal(new int[] {
+            16381302,
+            0,
+            0,
+            393216});
+            //
+            // AddMarkerBtn
+            //
+            this.AddMarkerBtn.Location = new System.Drawing.Point(678, 8);
+            this.AddMarkerBtn.Margin = new System.Windows.Forms.Padding(20, 4, 4, 4);
+            this.AddMarkerBtn.Name = "AddMarkerBtn";
+            this.AddMarkerBtn.Size = new System.Drawing.Size(120, 28);
+            this.AddMarkerBtn.TabIndex = 6;
+            this.AddMarkerBtn.Text = "Add marker";
+            this.AddMarkerBtn.UseVisualStyleBackColor = true;
+            this.AddMarkerBtn.Click += new System.EventHandler(this.AddMarkerBtn_Click);
+            //
+            // MyLocationBtn
+            //
+            this.MyLocationBtn.Location = new System.Drawing.Point(806, 8);
+            this.MyLocationBtn.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.MyLocationBtn.Name = "MyLocationBtn";
+            this.MyLocationBtn.Size = new System.Drawing.Size(120, 28);
+            this.MyLocationBtn.TabIndex = 7;
+            this.MyLocationBtn.Text = "My location";
+            this.MyLocationBtn.UseVisualStyleBackColor = true;
+            this.MyLocationBtn.Click += new System.EventHandler(this.MyLocationBtn_Click);
+            //
             // MainForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1067, 554);
-            this.Controls.Add(this.ZoomOutBtn);
-            this.Controls.Add(this.ZoomInBtn);
+            // The browser view is added first on purpose: WinForms lays docked
+            // controls out from the last control in the collection to the first,
+            // so the one that fills the remaining space must come first.
+            this.Controls.Add(this.browserView);
+            this.Controls.Add(this.mapControls);
             this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "MainForm";
-            this.Text = "Google Maps ";
+            this.Text = "Google Maps";
+            this.mapControls.ResumeLayout(false);
+            this.mapControls.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.latitudeValue)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.longitudeValue)).EndInit();
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
+        private DotNetBrowser.WinForms.BrowserView browserView;
+        private System.Windows.Forms.FlowLayoutPanel mapControls;
         private System.Windows.Forms.Button ZoomInBtn;
         private System.Windows.Forms.Button ZoomOutBtn;
+        private System.Windows.Forms.Label latitudeLabel;
+        private System.Windows.Forms.NumericUpDown latitudeValue;
+        private System.Windows.Forms.Label longitudeLabel;
+        private System.Windows.Forms.NumericUpDown longitudeValue;
+        private System.Windows.Forms.Button AddMarkerBtn;
+        private System.Windows.Forms.Button MyLocationBtn;
     }
 }
-

--- a/csharp/winforms/GoogleMaps/MainForm.cs
+++ b/csharp/winforms/GoogleMaps/MainForm.cs
@@ -19,81 +19,180 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endregion
-
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using DotNetBrowser.Browser;
+using DotNetBrowser.Browser.Handlers;
 using DotNetBrowser.Engine;
-using DotNetBrowser.WinForms;
+using DotNetBrowser.Handlers;
+using DotNetBrowser.Js;
+using DotNetBrowser.Permissions;
+using DotNetBrowser.Permissions.Handlers;
 
 namespace GoogleMaps.WinForms
 {
     /// <summary>
-    ///     This example demonstrates how to use Google Maps with DotNetBrowser.
-    ///     To make this sample work, please configure the valid Google API key in map.html(line 11)
+    ///     This example demonstrates how to display Google Maps in a WinForms
+    ///     application and drive the Maps JavaScript API from .NET: change the
+    ///     zoom level, put markers on the map, and center the map on the
+    ///     current location.
     /// </summary>
+    /// <remarks>
+    ///     To make this example work, configure a valid Google API key in
+    ///     map.html. Because the page is loaded from the local file system, the
+    ///     key must not be restricted by HTTP referrer.
+    ///     The "My location" button additionally requires the Google Maps
+    ///     Geolocation API to be enabled for the Chromium engine. See
+    ///     https://teamdev.com/dotnetbrowser/docs/guides/gs/engine/#google-apis
+    /// </remarks>
     public partial class MainForm : Form
     {
-        private const int MinZoomLevel = 0;
-        private const int MaxZoomLevel = 21;
+        private readonly IBrowser browser;
+        private readonly IEngine engine;
 
-        private int currentZoomLevel = 4; //The default value for Google Maps zoom
+        /// <summary>
+        ///     The wrapper for the map displayed on the page. Stays <c>null</c>
+        ///     until map.html reports that the Maps JavaScript API has loaded.
+        /// </summary>
+        private GoogleMap map;
 
-        private IBrowser Browser { get; }
-        private BrowserView BrowserView { get; }
-
-        private int CurrentZoomLevel
-        {
-            get { return currentZoomLevel; }
-
-            set
-            {
-                if (value != currentZoomLevel && value > MinZoomLevel && value < MaxZoomLevel)
-                {
-                    if (!Browser.IsDisposed)
-                    {
-                        currentZoomLevel = value;
-                        Browser.MainFrame.ExecuteJavaScript($"map.setZoom({currentZoomLevel})");
-                    }
-                }
-            }
-        }
-
-        private IEngine Engine { get; }
-
-        private string PathToMapFile => Path.GetFullPath("map.html");
+        private static string PathToMapFile => new Uri(Path.GetFullPath("map.html")).AbsoluteUri;
 
         public MainForm()
         {
             InitializeComponent();
 
-            Engine = EngineFactory.Create();
-            Browser = Engine.CreateBrowser();
-            BrowserView = new BrowserView {Dock = DockStyle.Fill};
+            engine = EngineFactory.Create();
 
-            BrowserView.InitializeFrom(Browser);
-            Controls.Add(BrowserView);
+            // #docfragment "GoogleMaps.Geolocation"
+            // navigator.geolocation asks for a permission, which is denied
+            // unless a permission handler grants it.
+            engine.Profiles.Default.Permissions.RequestPermissionHandler =
+                new Handler<RequestPermissionParameters, RequestPermissionResponse>(p =>
+                    p.Type == PermissionType.Geolocation
+                        ? RequestPermissionResponse.Grant()
+                        : RequestPermissionResponse.Deny());
+            // #enddocfragment "GoogleMaps.Geolocation"
 
-            Browser.Navigation.LoadUrl(PathToMapFile);
+            browser = engine.CreateBrowser();
 
-            Closed += MainForm_Closed;
+            // #docfragment "GoogleMaps.InjectExternal"
+            // Inject this form into the page as window.external, so that
+            // map.html can call back into .NET.
+            browser.InjectJsHandler = new Handler<InjectJsParameters>(OnInjectJs);
+            // #enddocfragment "GoogleMaps.InjectExternal"
+
+            browserView.InitializeFrom(browser);
+            browser.Navigation.LoadUrl(PathToMapFile);
+
+            FormClosed += MainForm_FormClosed;
         }
 
-        private void MainForm_Closed(object sender, EventArgs e)
+        /// <summary>
+        ///     Called from map.html when the current position has been determined.
+        /// </summary>
+        public void OnLocationDetected(double latitude, double longitude)
         {
-            Browser.Dispose();
-            Engine.Dispose();
+            BeginInvoke((Action) (() =>
+                                     {
+                                         latitudeValue.Value = (decimal) latitude;
+                                         longitudeValue.Value = (decimal) longitude;
+                                     }));
+        }
+
+        /// <summary>
+        ///     Called from map.html when the current position cannot be determined.
+        /// </summary>
+        public void OnLocationFailed(string message)
+        {
+            BeginInvoke((Action) (() => MessageBox.Show(this,
+                                                        message,
+                                                        "Geolocation is unavailable",
+                                                        MessageBoxButtons.OK,
+                                                        MessageBoxIcon.Warning)));
+        }
+
+        // #docfragment "GoogleMaps.MapInitialized"
+        /// <summary>
+        ///     Called from map.html once the Maps JavaScript API has loaded and
+        ///     the map has been created.
+        /// </summary>
+        public void OnMapInitialized(IJsObject jsMap)
+        {
+            map = new GoogleMap(jsMap);
+            BeginInvoke((Action) (() => mapControls.Enabled = true));
+        }
+        // #enddocfragment "GoogleMaps.MapInitialized"
+
+        private void AddMarkerBtn_Click(object sender, EventArgs e)
+        {
+            double latitude = decimal.ToDouble(latitudeValue.Value);
+            double longitude = decimal.ToDouble(longitudeValue.Value);
+            InvokeOnMap(m =>
+                           {
+                               m.SetCenter(latitude, longitude);
+                               m.AddMarker(latitude, longitude);
+                           });
+        }
+
+        /// <summary>
+        ///     Runs the given action on the map from a background thread.
+        /// </summary>
+        /// <remarks>
+        ///     The JavaScript calls the action makes block the calling thread
+        ///     until the browser returns the result, so they must not be made
+        ///     on the UI thread.
+        /// </remarks>
+        private void InvokeOnMap(Action<GoogleMap> action)
+        {
+            GoogleMap currentMap = map;
+            if (currentMap == null)
+            {
+                return;
+            }
+
+            Task.Run(() =>
+                        {
+                            try
+                            {
+                                action(currentMap);
+                            }
+                            catch (Exception exception)
+                            {
+                                Debug.WriteLine(exception);
+                            }
+                        });
+        }
+
+        private void MainForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            browser?.Dispose();
+            engine?.Dispose();
+        }
+
+        private void MyLocationBtn_Click(object sender, EventArgs e)
+        {
+            browser.MainFrame?.ExecuteJavaScript("showMyLocation()");
+        }
+
+        private void OnInjectJs(InjectJsParameters parameters)
+        {
+            // Inject window.external into the HTML page.
+            IJsObject window = parameters.Frame.ExecuteJavaScript<IJsObject>("window").Result;
+            window.Properties["external"] = this;
         }
 
         private void ZoomInBtn_Click(object sender, EventArgs e)
         {
-            CurrentZoomLevel++;
+            InvokeOnMap(m => m.Zoom++);
         }
 
         private void ZoomOutBtn_Click(object sender, EventArgs e)
         {
-            CurrentZoomLevel--;
+            InvokeOnMap(m => m.Zoom--);
         }
     }
 }

--- a/csharp/winforms/GoogleMaps/MainForm.cs
+++ b/csharp/winforms/GoogleMaps/MainForm.cs
@@ -108,8 +108,16 @@ namespace GoogleMaps.WinForms
         /// </summary>
         public void OnLocationFailed(string message)
         {
+            // Chromium reports an empty message when it cannot determine the
+            // position because the Google API keys are not configured.
+            string details = string.IsNullOrWhiteSpace(message)
+                ? "The current position could not be determined. Make sure the "
+                  + "Google Maps Geolocation API is enabled and the Google API "
+                  + "keys are configured through EngineOptions."
+                : message;
+
             BeginInvoke((Action) (() => MessageBox.Show(this,
-                                                        message,
+                                                        details,
                                                         "Geolocation is unavailable",
                                                         MessageBoxButtons.OK,
                                                         MessageBoxIcon.Warning)));

--- a/csharp/winforms/GoogleMaps/map.html
+++ b/csharp/winforms/GoogleMaps/map.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
  *  Copyright © 2026, TeamDev. All rights reserved.
  *
  *  Redistribution and use in source and/or binary forms, with or without
@@ -17,31 +17,109 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<!DOCTYPE html>  
-<html>  
-<head>  
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />  
-    <style type="text/css">  
-        html { height: 100% }  
-        body { height: 100%; margin: 0; padding: 0 }  
-        #map-canvas { height: 100% }  
-    </style>  
-    <script type="text/javascript"  
-            src="https://maps.googleapis.com/maps/api/js?key=API_KEY&sensor=false">  
-    </script>  
-    <script type="text/javascript">  
-        var map;  
-        function initialize() {  
-            var mapOptions = {  
-                center: new google.maps.LatLng(48.209331, 16.381302),  
-                zoom: 4  
-            };  
-            map = new google.maps.Map(document.getElementById("map-canvas"),  
-                mapOptions);  
-        }  
-        google.maps.event.addDomListener(window, 'load', initialize);  
-    </script>  
-</head>  
-<body>  
-<div id="map-canvas"/>  
-</body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <title>Google Maps</title>
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        #map {
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+
+<!--
+    The inline bootstrap loader recommended by Google. It loads the Maps
+    JavaScript API asynchronously and exposes google.maps.importLibrary().
+
+    Replace API_KEY below with a key of your own. This page is loaded from
+    disk, so the browser sends no HTTP referrer: a key restricted by HTTP
+    referrer is rejected with RefererNotAllowedMapError. Use an unrestricted
+    key, or serve the page over HTTP from an origin the key allows.
+-->
+<script>
+    (g => {
+        var h, a, k, p = "The Google Maps JavaScript API", c = "google", l = "importLibrary",
+            q = "__ib__", m = document, b = window;
+        b = b[c] || (b[c] = {});
+        var d = b.maps || (b.maps = {}), r = new Set(), e = new URLSearchParams(),
+            u = () => h || (h = new Promise(async (f, n) => {
+                await (a = m.createElement("script"));
+                e.set("libraries", [...r] + "");
+                for (k in g) e.set(k.replace(/[A-Z]/g, t => "_" + t[0].toLowerCase()), g[k]);
+                e.set("callback", c + ".maps." + q);
+                a.src = `https://maps.${c}apis.com/maps/api/js?` + e;
+                d[q] = f;
+                a.onerror = () => h = n(Error(p + " could not load."));
+                a.nonce = m.querySelector("script[nonce]")?.nonce || "";
+                m.head.append(a);
+            }));
+        d[l] ? console.warn(p + " only loads once. Ignoring:", g)
+             : d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n));
+    })({
+        key: "API_KEY",
+        v: "weekly"
+    });
+</script>
+
+<script>
+    // The map is exposed as a global so that the .NET side can obtain it
+    // with IFrame.ExecuteJavaScript<IJsObject>("map").
+    let map;
+
+    async function initMap() {
+        const {Map} = await google.maps.importLibrary("maps");
+
+        // The marker library is imported up front so that the .NET side can
+        // construct google.maps.marker.AdvancedMarkerElement right away.
+        await google.maps.importLibrary("marker");
+
+        map = new Map(document.getElementById("map"),
+            {
+                center: {lat: 48.209331, lng: 16.381302},
+                zoom: 4,
+                // Advanced markers require a map ID. DEMO_MAP_ID is the
+                // sandbox ID Google provides for samples; use a map ID of
+                // your own in a real application.
+                mapId: "DEMO_MAP_ID"
+            });
+
+        // Hand the map over to the .NET side. window.external is injected by
+        // the InjectJsHandler configured in MainForm.
+        window.external.OnMapInitialized(map);
+    }
+
+    // Asks Chromium for the current position and reports it back to .NET.
+    // The Geolocation permission is granted by the permission handler
+    // configured in MainForm.
+    function showMyLocation() {
+        navigator.geolocation.getCurrentPosition(
+            position => {
+                const location = {
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude
+                };
+                // Centering the map here rather than from .NET: the .NET
+                // callback below runs on the browser thread, which must not be
+                // blocked with another JavaScript call.
+                map.setCenter(location);
+                map.setZoom(14);
+                window.external.OnLocationDetected(location.lat, location.lng);
+            },
+            error => window.external.OnLocationFailed(error.message));
+    }
+
+    initMap().catch(error => console.error(error));
+</script>
+</body>
+</html>

--- a/csharp/winforms/GoogleStreetView/streetviewevents.htm
+++ b/csharp/winforms/GoogleStreetView/streetviewevents.htm
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Street View Events</title>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
     <script
         src="https://maps.googleapis.com/maps/api/js?key=API_KEY&callback=initPano&libraries=&v=weekly"
         defer></script>

--- a/vbnet/winforms/GoogleMaps/GoogleMap.vb
+++ b/vbnet/winforms/GoogleMaps/GoogleMap.vb
@@ -1,0 +1,107 @@
+#Region "Copyright"
+
+' Copyright © 2026, TeamDev. All rights reserved.
+' 
+' Redistribution and use in source and/or binary forms, with or without
+' modification, must retain the above copyright notice and the following
+' disclaimer.
+' 
+' THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+' "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+' LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+' A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+' OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+' SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+' LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+' DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+' THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+' (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#End Region
+Imports System
+Imports System.Globalization
+Imports DotNetBrowser.Frames
+Imports DotNetBrowser.Js
+
+Namespace GoogleMaps.WinForms
+	''' <summary>
+	'''     The wrapper class for the <c>google.maps.Map</c> object displayed on the page.
+	''' </summary>
+	Friend Class GoogleMap
+
+		''' <summary>
+		'''     The zoom levels supported by Google Maps.
+		''' </summary>
+		Private Const MinZoomLevel As Integer = 0
+		Private Const MaxZoomLevel As Integer = 21
+
+		Private ReadOnly map As IJsObject
+
+		''' <summary>
+		'''     Gets or sets the zoom level of the map. The value being set is
+		'''     clamped to the range supported by Google Maps.
+		''' </summary>
+		' #docfragment "GoogleMaps.Zoom"
+		Public Property Zoom() As Integer
+			Get
+				Return CInt(map.Invoke(Of Double)("getZoom"))
+			End Get
+
+			Set
+				Dim zoomLevel As Integer = Math.Min(MaxZoomLevel, Math.Max(MinZoomLevel, Value))
+				map.Invoke("setZoom", zoomLevel)
+			End Set
+		End Property
+		' #enddocfragment "GoogleMaps.Zoom"
+
+		Private ReadOnly Property Frame() As IFrame
+			Get
+				Return map.Frame
+			End Get
+		End Property
+
+		Public Sub New(jsMap As IJsObject)
+			If jsMap Is Nothing Then
+				Throw New ArgumentNullException(NameOf(jsMap))
+			End If
+			map = jsMap
+		End Sub
+
+		''' <summary>
+		'''     Puts a marker at the given position.
+		''' </summary>
+		Public Sub AddMarker(latitude As Double, longitude As Double)
+			' #docfragment "GoogleMaps.AddMarker"
+			' Create the marker in the page context and attach it to the map.
+			Dim marker As IJsObject =
+				Frame.ExecuteJavaScript(Of IJsObject)(
+					"new google.maps.marker.AdvancedMarkerElement({map: map})").Result
+
+			' AdvancedMarkerElement exposes the position as a property rather
+			' than through a setter method.
+			marker.Properties("position") = ToLatLngLiteral(latitude, longitude)
+			' #enddocfragment "GoogleMaps.AddMarker"
+		End Sub
+
+		''' <summary>
+		'''     Centers the map on the given position.
+		''' </summary>
+		Public Sub SetCenter(latitude As Double, longitude As Double)
+			map.Invoke("setCenter", ToLatLngLiteral(latitude, longitude))
+		End Sub
+
+		''' <summary>
+		'''     Creates a JavaScript <c>LatLngLiteral</c> object for the given coordinates.
+		''' </summary>
+		Private Function ToLatLngLiteral(latitude As Double, longitude As Double) As Object
+			' The invariant culture is used on purpose: JSON requires a dot as
+			' the decimal separator regardless of the current locale.
+			Dim json As String = String.Format(CultureInfo.InvariantCulture,
+											   "{{ ""lat"": {0}, ""lng"": {1} }}",
+											   latitude,
+											   longitude)
+			Return Frame.ParseJsonString(json)
+		End Function
+	End Class
+End Namespace

--- a/vbnet/winforms/GoogleMaps/GoogleMaps.WinForms.vbproj
+++ b/vbnet/winforms/GoogleMaps/GoogleMaps.WinForms.vbproj
@@ -98,6 +98,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GoogleMap.vb" />
     <Compile Include="MainForm.vb">
       <SubType>Form</SubType>
     </Compile>

--- a/vbnet/winforms/GoogleMaps/MainForm.Designer.vb
+++ b/vbnet/winforms/GoogleMaps/MainForm.Designer.vb
@@ -23,48 +23,167 @@ Namespace GoogleMaps.WinForms
 		''' the contents of this method with the code editor.
 		''' </summary>
 		Private Sub InitializeComponent()
+			Me.browserView = New DotNetBrowser.WinForms.BrowserView()
+			Me.mapControls = New System.Windows.Forms.FlowLayoutPanel()
 			Me.ZoomInBtn = New System.Windows.Forms.Button()
 			Me.ZoomOutBtn = New System.Windows.Forms.Button()
+			Me.latitudeLabel = New System.Windows.Forms.Label()
+			Me.latitudeValue = New System.Windows.Forms.NumericUpDown()
+			Me.longitudeLabel = New System.Windows.Forms.Label()
+			Me.longitudeValue = New System.Windows.Forms.NumericUpDown()
+			Me.AddMarkerBtn = New System.Windows.Forms.Button()
+			Me.MyLocationBtn = New System.Windows.Forms.Button()
+			Me.mapControls.SuspendLayout()
+			CType(Me.latitudeValue, System.ComponentModel.ISupportInitialize).BeginInit()
+			CType(Me.longitudeValue, System.ComponentModel.ISupportInitialize).BeginInit()
 			Me.SuspendLayout()
-			' 
+			'
+			' browserView
+			'
+			Me.browserView.Dock = System.Windows.Forms.DockStyle.Fill
+			Me.browserView.Location = New System.Drawing.Point(0, 46)
+			Me.browserView.Name = "browserView"
+			Me.browserView.Size = New System.Drawing.Size(1067, 508)
+			Me.browserView.TabIndex = 1
+			'
+			' mapControls
+			'
+			Me.mapControls.Controls.Add(Me.ZoomInBtn)
+			Me.mapControls.Controls.Add(Me.ZoomOutBtn)
+			Me.mapControls.Controls.Add(Me.latitudeLabel)
+			Me.mapControls.Controls.Add(Me.latitudeValue)
+			Me.mapControls.Controls.Add(Me.longitudeLabel)
+			Me.mapControls.Controls.Add(Me.longitudeValue)
+			Me.mapControls.Controls.Add(Me.AddMarkerBtn)
+			Me.mapControls.Controls.Add(Me.MyLocationBtn)
+			Me.mapControls.Dock = System.Windows.Forms.DockStyle.Top
+			' The controls stay disabled until the map reports that it is ready.
+			Me.mapControls.Enabled = False
+			Me.mapControls.Location = New System.Drawing.Point(0, 0)
+			Me.mapControls.Name = "mapControls"
+			Me.mapControls.Padding = New System.Windows.Forms.Padding(4, 4, 4, 4)
+			Me.mapControls.Size = New System.Drawing.Size(1067, 46)
+			Me.mapControls.TabIndex = 0
+			Me.mapControls.WrapContents = False
+			'
 			' ZoomInBtn
-			' 
-			Me.ZoomInBtn.Location = New System.Drawing.Point(927, 15)
+			'
+			Me.ZoomInBtn.Location = New System.Drawing.Point(8, 8)
 			Me.ZoomInBtn.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
 			Me.ZoomInBtn.Name = "ZoomInBtn"
 			Me.ZoomInBtn.Size = New System.Drawing.Size(100, 28)
 			Me.ZoomInBtn.TabIndex = 0
 			Me.ZoomInBtn.Text = "Zoom +"
 			Me.ZoomInBtn.UseVisualStyleBackColor = True
-			' 
+			'
 			' ZoomOutBtn
-			' 
-			Me.ZoomOutBtn.Location = New System.Drawing.Point(927, 50)
+			'
+			Me.ZoomOutBtn.Location = New System.Drawing.Point(116, 8)
 			Me.ZoomOutBtn.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
 			Me.ZoomOutBtn.Name = "ZoomOutBtn"
 			Me.ZoomOutBtn.Size = New System.Drawing.Size(100, 28)
 			Me.ZoomOutBtn.TabIndex = 1
 			Me.ZoomOutBtn.Text = "Zoom -"
 			Me.ZoomOutBtn.UseVisualStyleBackColor = True
-			' 
+			'
+			' latitudeLabel
+			'
+			Me.latitudeLabel.AutoSize = True
+			Me.latitudeLabel.Location = New System.Drawing.Point(240, 14)
+			Me.latitudeLabel.Margin = New System.Windows.Forms.Padding(20, 10, 4, 4)
+			Me.latitudeLabel.Name = "latitudeLabel"
+			Me.latitudeLabel.Size = New System.Drawing.Size(62, 17)
+			Me.latitudeLabel.TabIndex = 2
+			Me.latitudeLabel.Text = "Latitude:"
+			'
+			' latitudeValue
+			'
+			Me.latitudeValue.DecimalPlaces = 6
+			Me.latitudeValue.Increment = New Decimal(New Integer() {1, 0, 0, 65536})
+			Me.latitudeValue.Location = New System.Drawing.Point(310, 8)
+			Me.latitudeValue.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+			Me.latitudeValue.Maximum = New Decimal(New Integer() {90, 0, 0, 0})
+			Me.latitudeValue.Minimum = New Decimal(New Integer() {90, 0, 0, -2147483648})
+			Me.latitudeValue.Name = "latitudeValue"
+			Me.latitudeValue.Size = New System.Drawing.Size(120, 22)
+			Me.latitudeValue.TabIndex = 3
+			Me.latitudeValue.Value = New Decimal(New Integer() {48209331, 0, 0, 393216})
+			'
+			' longitudeLabel
+			'
+			Me.longitudeLabel.AutoSize = True
+			Me.longitudeLabel.Location = New System.Drawing.Point(454, 14)
+			Me.longitudeLabel.Margin = New System.Windows.Forms.Padding(20, 10, 4, 4)
+			Me.longitudeLabel.Name = "longitudeLabel"
+			Me.longitudeLabel.Size = New System.Drawing.Size(72, 17)
+			Me.longitudeLabel.TabIndex = 4
+			Me.longitudeLabel.Text = "Longitude:"
+			'
+			' longitudeValue
+			'
+			Me.longitudeValue.DecimalPlaces = 6
+			Me.longitudeValue.Increment = New Decimal(New Integer() {1, 0, 0, 65536})
+			Me.longitudeValue.Location = New System.Drawing.Point(534, 8)
+			Me.longitudeValue.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+			Me.longitudeValue.Maximum = New Decimal(New Integer() {180, 0, 0, 0})
+			Me.longitudeValue.Minimum = New Decimal(New Integer() {180, 0, 0, -2147483648})
+			Me.longitudeValue.Name = "longitudeValue"
+			Me.longitudeValue.Size = New System.Drawing.Size(120, 22)
+			Me.longitudeValue.TabIndex = 5
+			Me.longitudeValue.Value = New Decimal(New Integer() {16381302, 0, 0, 393216})
+			'
+			' AddMarkerBtn
+			'
+			Me.AddMarkerBtn.Location = New System.Drawing.Point(678, 8)
+			Me.AddMarkerBtn.Margin = New System.Windows.Forms.Padding(20, 4, 4, 4)
+			Me.AddMarkerBtn.Name = "AddMarkerBtn"
+			Me.AddMarkerBtn.Size = New System.Drawing.Size(120, 28)
+			Me.AddMarkerBtn.TabIndex = 6
+			Me.AddMarkerBtn.Text = "Add marker"
+			Me.AddMarkerBtn.UseVisualStyleBackColor = True
+			'
+			' MyLocationBtn
+			'
+			Me.MyLocationBtn.Location = New System.Drawing.Point(806, 8)
+			Me.MyLocationBtn.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+			Me.MyLocationBtn.Name = "MyLocationBtn"
+			Me.MyLocationBtn.Size = New System.Drawing.Size(120, 28)
+			Me.MyLocationBtn.TabIndex = 7
+			Me.MyLocationBtn.Text = "My location"
+			Me.MyLocationBtn.UseVisualStyleBackColor = True
+			'
 			' MainForm
-			' 
+			'
 			Me.AutoScaleDimensions = New System.Drawing.SizeF(8F, 16F)
 			Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
 			Me.ClientSize = New System.Drawing.Size(1067, 554)
-			Me.Controls.Add(Me.ZoomOutBtn)
-			Me.Controls.Add(Me.ZoomInBtn)
+			' The browser view is added first on purpose: WinForms lays docked
+			' controls out from the last control in the collection to the first,
+			' so the one that fills the remaining space must come first.
+			Me.Controls.Add(Me.browserView)
+			Me.Controls.Add(Me.mapControls)
 			Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
 			Me.Name = "MainForm"
-			Me.Text = "Google Maps "
+			Me.Text = "Google Maps"
+			Me.mapControls.ResumeLayout(False)
+			Me.mapControls.PerformLayout()
+			CType(Me.latitudeValue, System.ComponentModel.ISupportInitialize).EndInit()
+			CType(Me.longitudeValue, System.ComponentModel.ISupportInitialize).EndInit()
 			Me.ResumeLayout(False)
 
 		End Sub
 
 		#End Region
 
+		Private WithEvents browserView As DotNetBrowser.WinForms.BrowserView
+		Private WithEvents mapControls As System.Windows.Forms.FlowLayoutPanel
 		Private WithEvents ZoomInBtn As System.Windows.Forms.Button
 		Private WithEvents ZoomOutBtn As System.Windows.Forms.Button
+		Private WithEvents latitudeLabel As System.Windows.Forms.Label
+		Private WithEvents latitudeValue As System.Windows.Forms.NumericUpDown
+		Private WithEvents longitudeLabel As System.Windows.Forms.Label
+		Private WithEvents longitudeValue As System.Windows.Forms.NumericUpDown
+		Private WithEvents AddMarkerBtn As System.Windows.Forms.Button
+		Private WithEvents MyLocationBtn As System.Windows.Forms.Button
 	End Class
 End Namespace
-

--- a/vbnet/winforms/GoogleMaps/MainForm.vb
+++ b/vbnet/winforms/GoogleMaps/MainForm.vb
@@ -19,78 +19,171 @@
 ' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #End Region
-
+Imports System
+Imports System.Diagnostics
 Imports System.IO
+Imports System.Threading.Tasks
+Imports System.Windows.Forms
 Imports DotNetBrowser.Browser
+Imports DotNetBrowser.Browser.Handlers
 Imports DotNetBrowser.Engine
-Imports DotNetBrowser.WinForms
+Imports DotNetBrowser.Handlers
+Imports DotNetBrowser.Js
+Imports DotNetBrowser.Permissions
+Imports DotNetBrowser.Permissions.Handlers
 
 Namespace GoogleMaps.WinForms
-    ''' <summary>
-    '''     This example demonstrates how to use Google Maps with DotNetBrowser.
-    '''     To make this sample work, please configure the valid Google API key in map.html(line 11)
-    ''' </summary>
-    Partial Public Class MainForm
-        Inherits Form
+	''' <summary>
+	'''     This example demonstrates how to display Google Maps in a WinForms
+	'''     application and drive the Maps JavaScript API from .NET: change the
+	'''     zoom level, put markers on the map, and center the map on the
+	'''     current location.
+	''' </summary>
+	''' <remarks>
+	'''     To make this example work, configure a valid Google API key in
+	'''     map.html. Because the page is loaded from the local file system, the
+	'''     key must not be restricted by HTTP referrer.
+	'''     The "My location" button additionally requires the Google Maps
+	'''     Geolocation API to be enabled for the Chromium engine. See
+	'''     https://teamdev.com/dotnetbrowser/docs/guides/gs/engine/#google-apis
+	''' </remarks>
+	Partial Public Class MainForm
+		Inherits Form
 
-        Private Const MinZoomLevel As Integer = 0
-        Private Const MaxZoomLevel As Integer = 21
+		Private ReadOnly browser As IBrowser
+		Private ReadOnly engine As IEngine
 
-        Private zoomLevel As Integer = 4 'The default value for Google Maps zoom
+		''' <summary>
+		'''     The wrapper for the map displayed on the page. Stays <c>Nothing</c>
+		'''     until map.html reports that the Maps JavaScript API has loaded.
+		''' </summary>
+		Private map As GoogleMap
 
-        Private ReadOnly Property Browser() As IBrowser
-        Private ReadOnly Property BrowserView() As BrowserView
+		Private Shared ReadOnly Property PathToMapFile() As String
+			Get
+				Return (New Uri(Path.GetFullPath("map.html"))).AbsoluteUri
+			End Get
+		End Property
 
-        Private Property CurrentZoomLevel() As Integer
-            Get
-                Return zoomLevel
-            End Get
+		Public Sub New()
+			InitializeComponent()
 
-            Set
-                If value <> zoomLevel AndAlso value > MinZoomLevel AndAlso value < MaxZoomLevel Then
-                    If Not Browser.IsDisposed Then
-                        zoomLevel = value
-                        Browser.MainFrame.ExecuteJavaScript($"map.setZoom({zoomLevel})")
-                    End If
-                End If
-            End Set
-        End Property
+			engine = EngineFactory.Create()
 
-        Private ReadOnly Property Engine() As IEngine
+			' #docfragment "GoogleMaps.Geolocation"
+			' navigator.geolocation asks for a permission, which is denied
+			' unless a permission handler grants it.
+			engine.Profiles.Default.Permissions.RequestPermissionHandler =
+				New Handler(Of RequestPermissionParameters, RequestPermissionResponse)(
+					Function(p)
+						If p.Type = PermissionType.Geolocation Then
+							Return RequestPermissionResponse.Grant()
+						End If
+						Return RequestPermissionResponse.Deny()
+					End Function)
+			' #enddocfragment "GoogleMaps.Geolocation"
 
-        Private ReadOnly Property PathToMapFile() As String
-            Get
-                Return Path.GetFullPath("map.html")
-            End Get
-        End Property
+			browser = engine.CreateBrowser()
 
-        Public Sub New()
-            InitializeComponent()
+			' #docfragment "GoogleMaps.InjectExternal"
+			' Inject this form into the page as window.external, so that
+			' map.html can call back into .NET.
+			browser.InjectJsHandler = New Handler(Of InjectJsParameters)(AddressOf OnInjectJs)
+			' #enddocfragment "GoogleMaps.InjectExternal"
 
-            Engine = EngineFactory.Create()
-            Browser = Engine.CreateBrowser()
-            BrowserView = New BrowserView With {.Dock = DockStyle.Fill}
+			browserView.InitializeFrom(browser)
+			browser.Navigation.LoadUrl(PathToMapFile)
 
-            BrowserView.InitializeFrom(Browser)
-            Controls.Add(BrowserView)
+			AddHandler Me.FormClosed, AddressOf MainForm_FormClosed
+		End Sub
 
-            Browser.Navigation.LoadUrl(PathToMapFile)
+		''' <summary>
+		'''     Called from map.html when the current position has been determined.
+		''' </summary>
+		Public Sub OnLocationDetected(latitude As Double, longitude As Double)
+			BeginInvoke(New Action(Sub()
+									   latitudeValue.Value = CDec(latitude)
+									   longitudeValue.Value = CDec(longitude)
+								   End Sub))
+		End Sub
 
-            AddHandler Me.Closed, AddressOf MainForm_Closed
-        End Sub
+		''' <summary>
+		'''     Called from map.html when the current position cannot be determined.
+		''' </summary>
+		Public Sub OnLocationFailed(message As String)
+			BeginInvoke(New Action(Sub()
+									   MessageBox.Show(Me,
+													   message,
+													   "Geolocation is unavailable",
+													   MessageBoxButtons.OK,
+													   MessageBoxIcon.Warning)
+								   End Sub))
+		End Sub
 
-        Private Sub MainForm_Closed(ByVal sender As Object, ByVal e As EventArgs)
-            Browser.Dispose()
-            Engine.Dispose()
-        End Sub
+		' #docfragment "GoogleMaps.MapInitialized"
+		''' <summary>
+		'''     Called from map.html once the Maps JavaScript API has loaded and
+		'''     the map has been created.
+		''' </summary>
+		Public Sub OnMapInitialized(jsMap As IJsObject)
+			map = New GoogleMap(jsMap)
+			BeginInvoke(New Action(Sub() mapControls.Enabled = True))
+		End Sub
+		' #enddocfragment "GoogleMaps.MapInitialized"
 
-        Private Sub ZoomInBtn_Click(ByVal sender As Object, ByVal e As EventArgs) Handles ZoomInBtn.Click
-            CurrentZoomLevel += 1
-        End Sub
+		Private Sub AddMarkerBtn_Click(sender As Object, e As EventArgs) Handles AddMarkerBtn.Click
+			Dim latitude As Double = Decimal.ToDouble(latitudeValue.Value)
+			Dim longitude As Double = Decimal.ToDouble(longitudeValue.Value)
+			InvokeOnMap(Sub(m)
+							m.SetCenter(latitude, longitude)
+							m.AddMarker(latitude, longitude)
+						End Sub)
+		End Sub
 
-        Private Sub ZoomOutBtn_Click(ByVal sender As Object, ByVal e As EventArgs) Handles ZoomOutBtn.Click
-            CurrentZoomLevel -= 1
-        End Sub
+		''' <summary>
+		'''     Runs the given action on the map from a background thread.
+		''' </summary>
+		''' <remarks>
+		'''     The JavaScript calls the action makes block the calling thread
+		'''     until the browser returns the result, so they must not be made
+		'''     on the UI thread.
+		''' </remarks>
+		Private Sub InvokeOnMap(action As Action(Of GoogleMap))
+			Dim currentMap As GoogleMap = map
+			If currentMap Is Nothing Then
+				Return
+			End If
 
-    End Class
+			Task.Run(Sub()
+						 Try
+							 action(currentMap)
+						 Catch exception As Exception
+							 Debug.WriteLine(exception)
+						 End Try
+					 End Sub)
+		End Sub
+
+		Private Sub MainForm_FormClosed(sender As Object, e As FormClosedEventArgs)
+			browser?.Dispose()
+			engine?.Dispose()
+		End Sub
+
+		Private Sub MyLocationBtn_Click(sender As Object, e As EventArgs) Handles MyLocationBtn.Click
+			browser.MainFrame?.ExecuteJavaScript("showMyLocation()")
+		End Sub
+
+		Private Sub OnInjectJs(parameters As InjectJsParameters)
+			' Inject window.external into the HTML page.
+			Dim window As IJsObject = parameters.Frame.ExecuteJavaScript(Of IJsObject)("window").Result
+			window.Properties("external") = Me
+		End Sub
+
+		Private Sub ZoomInBtn_Click(sender As Object, e As EventArgs) Handles ZoomInBtn.Click
+			InvokeOnMap(Sub(m) m.Zoom += 1)
+		End Sub
+
+		Private Sub ZoomOutBtn_Click(sender As Object, e As EventArgs) Handles ZoomOutBtn.Click
+			InvokeOnMap(Sub(m) m.Zoom -= 1)
+		End Sub
+	End Class
 End Namespace

--- a/vbnet/winforms/GoogleMaps/MainForm.vb
+++ b/vbnet/winforms/GoogleMaps/MainForm.vb
@@ -111,9 +111,17 @@ Namespace GoogleMaps.WinForms
 		'''     Called from map.html when the current position cannot be determined.
 		''' </summary>
 		Public Sub OnLocationFailed(message As String)
+			' Chromium reports an empty message when it cannot determine the
+			' position because the Google API keys are not configured.
+			Dim details As String = If(String.IsNullOrWhiteSpace(message),
+									   "The current position could not be determined. Make sure the " &
+									   "Google Maps Geolocation API is enabled and the Google API " &
+									   "keys are configured through EngineOptions.",
+									   message)
+
 			BeginInvoke(New Action(Sub()
 									   MessageBox.Show(Me,
-													   message,
+													   details,
 													   "Geolocation is unavailable",
 													   MessageBoxButtons.OK,
 													   MessageBoxIcon.Warning)

--- a/vbnet/winforms/GoogleMaps/map.html
+++ b/vbnet/winforms/GoogleMaps/map.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
  *  Copyright © 2026, TeamDev. All rights reserved.
  *
  *  Redistribution and use in source and/or binary forms, with or without
@@ -17,31 +17,109 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-<!DOCTYPE html>  
-<html>  
-<head>  
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />  
-    <style type="text/css">  
-        html { height: 100% }  
-        body { height: 100%; margin: 0; padding: 0 }  
-        #map-canvas { height: 100% }  
-    </style>  
-    <script type="text/javascript"  
-            src="https://maps.googleapis.com/maps/api/js?key=API_KEY&sensor=false">  
-    </script>  
-    <script type="text/javascript">  
-        var map;  
-        function initialize() {  
-            var mapOptions = {  
-                center: new google.maps.LatLng(48.209331, 16.381302),  
-                zoom: 4  
-            };  
-            map = new google.maps.Map(document.getElementById("map-canvas"),  
-                mapOptions);  
-        }  
-        google.maps.event.addDomListener(window, 'load', initialize);  
-    </script>  
-</head>  
-<body>  
-<div id="map-canvas"/>  
-</body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <title>Google Maps</title>
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        #map {
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+
+<!--
+    The inline bootstrap loader recommended by Google. It loads the Maps
+    JavaScript API asynchronously and exposes google.maps.importLibrary().
+
+    Replace API_KEY below with a key of your own. This page is loaded from
+    disk, so the browser sends no HTTP referrer: a key restricted by HTTP
+    referrer is rejected with RefererNotAllowedMapError. Use an unrestricted
+    key, or serve the page over HTTP from an origin the key allows.
+-->
+<script>
+    (g => {
+        var h, a, k, p = "The Google Maps JavaScript API", c = "google", l = "importLibrary",
+            q = "__ib__", m = document, b = window;
+        b = b[c] || (b[c] = {});
+        var d = b.maps || (b.maps = {}), r = new Set(), e = new URLSearchParams(),
+            u = () => h || (h = new Promise(async (f, n) => {
+                await (a = m.createElement("script"));
+                e.set("libraries", [...r] + "");
+                for (k in g) e.set(k.replace(/[A-Z]/g, t => "_" + t[0].toLowerCase()), g[k]);
+                e.set("callback", c + ".maps." + q);
+                a.src = `https://maps.${c}apis.com/maps/api/js?` + e;
+                d[q] = f;
+                a.onerror = () => h = n(Error(p + " could not load."));
+                a.nonce = m.querySelector("script[nonce]")?.nonce || "";
+                m.head.append(a);
+            }));
+        d[l] ? console.warn(p + " only loads once. Ignoring:", g)
+             : d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n));
+    })({
+        key: "API_KEY",
+        v: "weekly"
+    });
+</script>
+
+<script>
+    // The map is exposed as a global so that the .NET side can obtain it
+    // with IFrame.ExecuteJavaScript<IJsObject>("map").
+    let map;
+
+    async function initMap() {
+        const {Map} = await google.maps.importLibrary("maps");
+
+        // The marker library is imported up front so that the .NET side can
+        // construct google.maps.marker.AdvancedMarkerElement right away.
+        await google.maps.importLibrary("marker");
+
+        map = new Map(document.getElementById("map"),
+            {
+                center: {lat: 48.209331, lng: 16.381302},
+                zoom: 4,
+                // Advanced markers require a map ID. DEMO_MAP_ID is the
+                // sandbox ID Google provides for samples; use a map ID of
+                // your own in a real application.
+                mapId: "DEMO_MAP_ID"
+            });
+
+        // Hand the map over to the .NET side. window.external is injected by
+        // the InjectJsHandler configured in MainForm.
+        window.external.OnMapInitialized(map);
+    }
+
+    // Asks Chromium for the current position and reports it back to .NET.
+    // The Geolocation permission is granted by the permission handler
+    // configured in MainForm.
+    function showMyLocation() {
+        navigator.geolocation.getCurrentPosition(
+            position => {
+                const location = {
+                    lat: position.coords.latitude,
+                    lng: position.coords.longitude
+                };
+                // Centering the map here rather than from .NET: the .NET
+                // callback below runs on the browser thread, which must not be
+                // blocked with another JavaScript call.
+                map.setCenter(location);
+                map.setZoom(14);
+                window.external.OnLocationDetected(location.lat, location.lng);
+            },
+            error => window.external.OnLocationFailed(error.message));
+    }
+
+    initMap().catch(error => console.error(error));
+</script>
+</body>
+</html>

--- a/vbnet/winforms/GoogleStreetView/streetviewevents.htm
+++ b/vbnet/winforms/GoogleStreetView/streetviewevents.htm
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Street View Events</title>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
     <script
         src="https://maps.googleapis.com/maps/api/js?key=API_KEY&callback=initPano&libraries=&v=weekly"
         defer></script>


### PR DESCRIPTION
The WinForms Google Maps example was ported to the DotNetBrowser 2 API in
2020 and has had no content change since. Its `map.html` still loaded the
Maps JavaScript API the way it was loaded in 2013, and the .NET side did
nothing but push a string of JavaScript at the page.

